### PR TITLE
Deploy to PyPI on releases

### DIFF
--- a/.github/workflows/flownet.yml
+++ b/.github/workflows/flownet.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - master
+  release:
+    types:
+      - published
   
 jobs:
   FlowNet:
@@ -78,6 +81,16 @@ jobs:
           pushd docs
           make html
           popd
+
+      - name: Build and deploy Python package
+        if: github.event_name == 'release' && matrix.python-version == '3.6'
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.pypi_flownet_token }}
+        run: |
+          python -m pip install --upgrade setuptools wheel twine
+          python setup.py bdist_wheel
+          twine upload dist/*
 
       - name: Update GitHub pages
         if: github.ref == 'refs/heads/master' && matrix.python-version == '3.6'

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![PyPI version](https://badge.fury.io/py/flownet.svg)](https://badge.fury.io/py/flownet)
 [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/equinor/flownet/CI)](https://github.com/equinor/flownet/actions?query=workflow%3ACI)
 [![Python 3.6 | 3.7](https://img.shields.io/badge/python-3.6%20|%203.7-blue.svg)](https://www.python.org/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
@@ -28,7 +29,7 @@ to get going.
 
 _FlowNet_ uses the open-source reservoir simulator [_OPM-Flow_](https://opm-project.org/?page_id=19). To be able to run _FlowNet_ you will need to have _OPM-Flow_
 installed first. There are also other dependencies like the Python packages [`libecl`](https://github.com/equinor/libecl) and
-[`libres`](https://github.com/equinor/libres) which currently are not easily installable from PyPI.
+[`libres`](https://github.com/equinor/libres) which currently are not easily installable from PyPI (however, things are happening, so hopefully in a not too distant future, dependencies are installable from PyPI, which is already the case for flownet itself: `pip install flownet`).
 
 ##### 1. Clone the _FlowNet_ GitHub repository with SSH:
 ```bash

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,8 @@
 from setuptools import setup, find_packages
 
+with open("README.md", "r") as fh:
+    LONG_DESCRIPTION = fh.read()
+
 REQUIREMENTS = [
     "configsuite~=0.5",
     "cwrap~=1.6",
@@ -36,11 +39,13 @@ setup(
     setup_requires=["setuptools_scm~=3.2"],
     extras_require={"tests": TEST_REQUIRES},
     description="Simplified training of reservoir simulation models",
+    long_description=LONG_DESCRIPTION,
+    long_description_content_type="text/markdown",
     url="https://github.com/equinor/flownet",
     author="R&T Equinor",
     use_scm_version=True,
     package_dir={"": "src"},
-    packages=find_packages("src", exclude=["tests"]),
+    packages=find_packages("src"),
     package_data={"flownet": ["templates/*", "static/*"]},
     entry_points={
         "console_scripts": [
@@ -51,4 +56,11 @@ setup(
         ]
     },
     zip_safe=False,
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "Operating System :: OS Independent",
+        "Natural Language :: English",
+        "Topic :: Scientific/Engineering",
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    ],
 )


### PR DESCRIPTION
This finishes the `flownet` part of PyPI deploy.

- [x] `libecl` is already on PyPI.
- [ ] `libres` dependency available on PyPI (in progress by Equinor).
- [ ] `opm-io`  indirect dependency available on PyPI (assigned to Ceetron Solutions).