### PR TITLE
Put back resampling

### DIFF
--- a/src/flownet/data/from_eclipse.py
+++ b/src/flownet/data/from_eclipse.py
@@ -165,6 +165,9 @@ class EclipseData(FromSource):
                 # Set columns that have only exact zero values to np.nan
                 df.loc[:, (df == 0).all(axis=0)] = np.nan
 
+                if self._resample is not None:
+                    df = df.resample(self._resample).mean().interpolate(method="linear")
+
                 df["WELL_NAME"] = well_name
                 df_production_data = df_production_data.append(df)
 


### PR DESCRIPTION
Closes #64 

Any good reason not to put back the resampling? @anders-kiaer @olwijn 

Not having the resampling makes the Norne test case run extremely slow and the CI unworkable. Additionally, it removes the resampling functionality but in the code/configs it still looks it should work.

If you for some reason do not want resampling, it is just as easy to not set the resampling parameter or set it to None in the config.
