### PR TITLE
Fixes bug in analysis workflow

### DIFF
--- a/src/flownet/ahm/_ahm_iteration_analytics.py
+++ b/src/flownet/ahm/_ahm_iteration_analytics.py
@@ -379,7 +379,7 @@ def save_iteration_analytics():
     config = parse_config(pathlib.Path(args.config))
 
     field_data = FlowData(
-        config.flownet.data_source.eclipse_case,
+        config.flownet.data_source.input_case,
         perforation_handling_strategy=config.flownet.perforation_handling_strategy,
     )
     df_obs: pd.DataFrame = field_data.production

--- a/src/flownet/ahm/_ahm_iteration_analytics.py
+++ b/src/flownet/ahm/_ahm_iteration_analytics.py
@@ -15,7 +15,7 @@ from sklearn.metrics import mean_squared_error, mean_absolute_error, r2_score
 from ecl.summary import EclSum
 
 from ..config_parser import parse_config
-from ..data import EclipseData
+from ..data import FlowData
 
 
 def filter_dataframe(df_in, key_filter, min_value, max_value):
@@ -378,7 +378,7 @@ def save_iteration_analytics():
     # Load reference simulation (OPM-Flow/Eclipse)
     config = parse_config(pathlib.Path(args.config))
 
-    field_data = EclipseData(
+    field_data = FlowData(
         config.flownet.data_source.eclipse_case,
         perforation_handling_strategy=config.flownet.perforation_handling_strategy,
     )

--- a/src/flownet/ahm/_ahm_iteration_analytics.py
+++ b/src/flownet/ahm/_ahm_iteration_analytics.py
@@ -258,7 +258,6 @@ def make_dataframe_simulation_data(path, eclbase_file, keys):
     # Load summary files of latest iteration
     # with concurrent.futures.ProcessPoolExecutor() as executor:
     for runpath, eclbase in list(zip(runpath_list, itertools.repeat(eclbase_file))):
-        print(runpath, eclbase)
         realizations_dict[runpath] = _load_simulations(runpath, eclbase)
 
     # Prepare dataframe
@@ -392,10 +391,6 @@ def save_iteration_analytics():
     # Filter dataframe base on measurement dates
     df_obs = df_obs[df_obs["DATE"].isin(df_sim["DATE"])]
     df_sim = df_sim[df_sim["DATE"].isin(df_obs["DATE"])]
-
-    print(df_obs["DATE"].values)
-    print(df_sim["DATE"].values)
-    print("compare!\n")
 
     # Initiate dataframe with metrics
     df_metrics = load_csv_file(args.outfile, ["quantity", "iteration"] + metrics)

--- a/src/flownet/ahm/_ahm_iteration_analytics.py
+++ b/src/flownet/ahm/_ahm_iteration_analytics.py
@@ -15,11 +15,7 @@ from sklearn.metrics import mean_squared_error, mean_absolute_error, r2_score
 from ecl.summary import EclSum
 
 from ..config_parser import parse_config
-<<<<<<< HEAD
 from ..data import FlowData
-=======
-from ..data import EclipseData
->>>>>>> 440b407881044fa8fa97415c310997532d62707e
 
 
 def filter_dataframe(df_in, key_filter, min_value, max_value):
@@ -382,13 +378,8 @@ def save_iteration_analytics():
     # Load reference simulation (OPM-Flow/Eclipse)
     config = parse_config(pathlib.Path(args.config))
 
-<<<<<<< HEAD
     field_data = FlowData(
         config.flownet.data_source.input_case,
-=======
-    field_data = EclipseData(
-        config.flownet.data_source.eclipse_case,
->>>>>>> 440b407881044fa8fa97415c310997532d62707e
         perforation_handling_strategy=config.flownet.perforation_handling_strategy,
     )
     df_obs: pd.DataFrame = field_data.production


### PR DESCRIPTION
Partially addresses #61.

A new way of loading data from the reference simulation (OPM-Flow/Eclipse) is added, using functionality from `flownet.data.from_eclipse` instead of the previous approach of fetching data from the observation file into dictionary which was causing the random order behavior