### PR TITLE
Remove unnecessary apt-get installs

### DIFF
--- a/apt_install.sh
+++ b/apt_install.sh
@@ -1,11 +1,10 @@
 apt-get install zlib1g-dev  # libecl
 apt-get install libblas-dev liblapack-dev  # libres
 apt-get install libnss3-tools # webviz
-apt-get install libboost-all-dev liblapack-dev # opm-common
 
 # Flow:
+apt-get update
 apt-get install software-properties-common -y
-apt-get install libdune-common-dev libdune-geometry-dev -y
 apt-add-repository ppa:opm/ppa -y
 apt-get update
 apt-get install mpi-default-bin libopm-simulators-bin -y


### PR DESCRIPTION
Some `apt-install` commands are now obsolete after we can do `pip install opm`.