### PR TITLE
Fixed bug where the config would be parsed incorrectly when no aquifer is defined

### DIFF
--- a/src/flownet/config_parser/_config_parser.py
+++ b/src/flownet/config_parser/_config_parser.py
@@ -552,7 +552,9 @@ def parse_config(configuration_file: pathlib.Path) -> ConfigSuite.snapshot:
             "'scheme', 'fraction', 'delta_depth' and a 'size_in_bulkvolumes' distribution ('min', 'max', 'logunif')."
             "Currently one or more parameters are missing."
         )
-    if not all(config.model_parameters.aquifer.size_in_bulkvolumes):
+    if all(config.model_parameters.aquifer[0:3]) and not all(
+        config.model_parameters.aquifer.size_in_bulkvolumes
+    ):
         raise ValueError(
             "Ambiguous configuration input: 'size_in_bulkvolumes' in 'aquifer' needs to be defined using "
             "'min', 'max' and 'log_unif'. Currently one or more parameters are missing."

--- a/src/flownet/network_model/_generate_connections.py
+++ b/src/flownet/network_model/_generate_connections.py
@@ -453,7 +453,7 @@ def create_connections(
     aquifer_ends: List[Coordinate] = []
 
     aquifer_config = configuration.model_parameters.aquifer
-    if aquifer_config is not None:
+    if all(aquifer_config[0:3]) and all(aquifer_config.size_in_bulkvolumes):
         scheme = aquifer_config.scheme
         fraction = aquifer_config.fraction
         delta_depth = aquifer_config.delta_depth


### PR DESCRIPTION
Closes #105 