### PR TITLE
Bump ert and libres dependencies

### DIFF
--- a/build_environment.sh
+++ b/build_environment.sh
@@ -12,8 +12,8 @@
 # the given path. The second argument is the path to your installed flow binary, typically
 # something like /usr/bin/flow
 
-LIBRES_VERSION="6d7ac59"
-ERT_VERSION="c74e1e6"
+LIBRES_VERSION="faec0bb"  # v4.2.2
+ERT_VERSION="68f8919"  # v2.13.0
 
 set -e
 


### PR DESCRIPTION
Might be related to #114. Bump `ert` and `libres` to latest released versions, and see if problem with hanging realizations in `ert` disappears.