### PR TITLE
Speed up ray tracing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ REQUIREMENTS = [
     "pyyaml>=5.2",
     "scikit-learn>=0.22",
     "scipy>=1.4",
-    "tqdm>=4.43",
     "webviz-config>=0.0.42",
     "webviz-config-equinor>=0.0.9",
     "webviz-subsurface>=0.0.24",

--- a/src/flownet/network_model/_network_model.py
+++ b/src/flownet/network_model/_network_model.py
@@ -348,9 +348,12 @@ class NetworkModel:
             if len(cells_in_fault) > 0:
                 dict_fault_keyword[fault_name].extend(cells_in_fault)
 
-        # Remove double entries
+        # Remove empty and double entries
         for fault_name in fault_names:
-            dict_fault_keyword[fault_name] = list(set(dict_fault_keyword[fault_name]))
+            if not dict_fault_keyword[fault_name]:
+                dict_fault_keyword.pop(fault_name)
+            else:
+                dict_fault_keyword[fault_name] = list(set(dict_fault_keyword[fault_name]))
 
         print("done.")
 

--- a/src/flownet/network_model/_network_model.py
+++ b/src/flownet/network_model/_network_model.py
@@ -237,8 +237,8 @@ class NetworkModel:
         Calculates fault definitions using the following approach:
 
             1) Loop through all faults
-            2) Perform a triangulation of all points belonging to a fault
-            3) For each triangle, perform ray tracing using the
+            2) Perform a triangulation of all points belonging to a fault plane and store the triangles
+            3) For each connection, find all triangles in its bounding box, perform ray tracing using the
                Möller-Trumbore intersection algorithm.
             4) If an intersection is found, identify the grid blocks that are
                associated with the intersection.
@@ -253,7 +253,6 @@ class NetworkModel:
             Listing of tuples of FAULTS entries with zero-offset i-coordinates, or None if no faults are present.
 
         """
-
         dict_fault_keyword: Dict[str, List[int]] = {}
         if self._fault_planes is not None:
             fault_names = self._fault_planes["NAME"].unique().tolist()
@@ -353,7 +352,9 @@ class NetworkModel:
             if not dict_fault_keyword[fault_name]:
                 dict_fault_keyword.pop(fault_name)
             else:
-                dict_fault_keyword[fault_name] = list(set(dict_fault_keyword[fault_name]))
+                dict_fault_keyword[fault_name] = list(
+                    set(dict_fault_keyword[fault_name])
+                )
 
         print("done.")
 

--- a/src/flownet/utils/raytracing.py
+++ b/src/flownet/utils/raytracing.py
@@ -1,11 +1,10 @@
-from typing import Tuple, Any
+from typing import Optional
 
 import numpy as np
 
 
 # pylint: disable=too-many-arguments,too-many-locals
 def moller_trumbore(
-    index: int,
     xstart: float,
     ystart: float,
     zstart: float,
@@ -21,7 +20,7 @@ def moller_trumbore(
     v31: float,
     v32: float,
     v33: float,
-) -> Tuple[Any, Any]:
+) -> Optional[float]:
     """
     The Möller–Trumbore ray-triangle intersection algorithm, named after its inventors Tomas Möller and Ben Trumbore,
     is a fast method for calculating the intersection of a ray and a triangle in three dimensions without
@@ -31,7 +30,6 @@ def moller_trumbore(
     (a collection of triangles).
 
     Args:
-        index: Tube index
         xstart: X-coordinate of the start point of the tube
         ystart: Y-coordinate of the start point of the tube
         zstart: Z-coordinate of the start point of the tube
@@ -49,8 +47,7 @@ def moller_trumbore(
         v33: Triangle corner 3 Z-coordinate
 
     Returns:
-        Tuple of the float representing the fraction of the tube where the intersection happened as well as
-        the tube index it happened in, otherwise False, False
+        Either a float representing the fraction of the tube where the intersection happened or None
 
     """
     eps = 0.000001
@@ -64,27 +61,27 @@ def moller_trumbore(
     det = edge1.dot(pvec)
 
     if abs(det) < eps:
-        return False, False
+        return None
 
     inv_det = 1.0 / det
     t_vector = ray_start - triangle[0]
     u_value = t_vector.dot(pvec) * inv_det
 
     if u_value < 0.0 or u_value > 1.0:
-        return False, False
+        return None
 
     q_vector = np.cross(t_vector, edge1)
     v_value = ray_direction.dot(q_vector) * inv_det
 
     if v_value < 0.0 or u_value + v_value > 1.0:
-        return False, False
+        return None
 
     ray_fraction = edge2.dot(q_vector) * inv_det
 
     if ray_fraction < eps:
-        return False, False
+        return None
 
     if ray_fraction > 1:
-        return False, False
+        return None
 
-    return ray_fraction, index
+    return ray_fraction


### PR DESCRIPTION
Close #102 

The ray tracing is now performed:

1) Loop through all faults
2) Perform a triangulation of all points belonging to a fault plane and store the triangles
3) For each connection, find all triangles in its bounding box, perform ray tracing using the Möller-Trumbore intersection algorithm.
4) If an intersection is found, identify the grid blocks that are associated with the intersection.

The process has now been reduced in time from multiple minutes to seconds (depending on the config settings).