### PR TITLE
Fix WCONINJH template

### DIFF
--- a/src/flownet/templates/HISTORY_SCHEDULE.inc.jinja2
+++ b/src/flownet/templates/HISTORY_SCHEDULE.inc.jinja2
@@ -36,10 +36,10 @@ WCONHIST
 
 {%- if schedule.get_keywords(date=date, kw_class="WCONINJH"): %}
 WCONINJH
--- WELL FLUID OPEN/ SURF RESV BHP   THP  VFP   NOT  CNTL
--- NAME TYPE  SHUT  RATE RATE PRSES PRES TABLE USED MODE
+-- WELL FLUID OPEN/ SURF BHP   THP  VFP   4 NOT TAR
+-- NAME TYPE  SHUT  RATE PRSES PRES TABLE USED  GET
 {%- for kw in schedule.get_keywords(date=date, kw_class="WCONINJH"): %}
- '{{ kw.well_name }}' '{{ kw.inj_type }}' '{{ kw.status }}' {{ kw.rate | isnan }} {{ kw.bhp | isnan }} {{ kw.thp | isnan }} {{ kw.vfp_table }} {{ kw.target }} /
+ '{{ kw.well_name }}' '{{ kw.inj_type }}' '{{ kw.status }}' {{ kw.rate | isnan }} {{ kw.bhp | isnan }} {{ kw.thp | isnan }} {{ kw.vfp_table }} 4* {{ kw.target }} /
 {%- endfor %}
 /
 


### PR DESCRIPTION
Closes #140 

NB. Target is currently set to `1* = RATE`; we could consider exposing this setting to the user, like:

```yaml
flownet:
  schedule:
    injection_target: BHP
```
