### PR TITLE
Add CODEOWNERS and deploy docs on merge to master

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+*     @anders-kiaer @wouterjdb @olelod
+

--- a/.github/workflows/flownet.yml
+++ b/.github/workflows/flownet.yml
@@ -115,7 +115,7 @@ jobs:
           twine upload dist/*
 
       - name: 📚 Update GitHub pages
-        if: github.event_name == 'release' && matrix.python-version == '3.6'
+        if: github.event_name != 'schedule' && github.ref == 'refs/heads/master' && matrix.python-version == '3.6'
         run: |
           cp -R ./docs/_build ../_build
           git config --local user.email "flownet-github-action"


### PR DESCRIPTION
Add GitHub `CODEOWNER`, and also (since we are in a rapid development phase) deploy documentation to GitHub pages on merges to `master` (instead of only on releases).

---

### Contributor checklist

- [X] :tada: This PR closes #151.
- [X] :scroll: I have broken down my PR into the following tasks:
   - [X] Add `CODEOWNER`
   - [X] Change CI workflow
- [X] ~:robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.~
- [X] :book: I have considered adding a new entry in `CHANGELOG.md`.
- [X] :books: I have considered updating the documentation.