### PR TITLE
Return CLI help if no arguments supplied to flownet

### DIFF
--- a/src/flownet/_command_line.py
+++ b/src/flownet/_command_line.py
@@ -1,3 +1,4 @@
+import sys
 import argparse
 import shutil
 import pathlib
@@ -203,6 +204,11 @@ def main():
     parser_hyperparam.set_defaults(func=flownet_hyperparam)
 
     args = parser.parse_args()
+
+    if len(sys.argv) <= 1:
+        parser.print_help(sys.stderr)
+        sys.exit(1)
+
     args.func(args)
 
 


### PR DESCRIPTION
Running `flownet` without arguments no returns the help instead of an empty `Namespace()` error.

---

### Contributor checklist

- [x] :tada: This PR closes #178
- [x] :scroll: I have broken down my PR into the following tasks:
   - [x] Add return help
- [x] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have considered adding a new entry in `CHANGELOG.md`.
- [x] :books: I have considered updating the documentation.