### PR TITLE
Use source model SATNUM regions when generating a FlowNet

### DIFF
--- a/.github/workflows/flownet.yml
+++ b/.github/workflows/flownet.yml
@@ -48,7 +48,7 @@ jobs:
           TESTDATA_REPO_OWNER: equinor
           # If you want the CI to (temporarily) run against another branch than master,
           # change the value her from "master" to the relevant branch name.
-          TESTDATA_REPO_BRANCH: master
+          TESTDATA_REPO_BRANCH: satnum-regions
         run: |
           git clone --depth 1 --branch $TESTDATA_REPO_BRANCH https://github.com/$TESTDATA_REPO_OWNER/flownet-testdata.git --recursive
           for f in $INPUT_MODEL_FOLDER/*.tar.gz; do tar -zxvf "$f" -C $INPUT_MODEL_FOLDER; done

--- a/.github/workflows/flownet.yml
+++ b/.github/workflows/flownet.yml
@@ -48,7 +48,7 @@ jobs:
           TESTDATA_REPO_OWNER: equinor
           # If you want the CI to (temporarily) run against another branch than master,
           # change the value her from "master" to the relevant branch name.
-          TESTDATA_REPO_BRANCH: satnum-regions
+          TESTDATA_REPO_BRANCH: master
         run: |
           git clone --depth 1 --branch $TESTDATA_REPO_BRANCH https://github.com/$TESTDATA_REPO_OWNER/flownet-testdata.git --recursive
           for f in $INPUT_MODEL_FOLDER/*.tar.gz; do tar -zxvf "$f" -C $INPUT_MODEL_FOLDER; done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
-- [#188](https://github.com/equinor/flownet/pull/188) The possibility to extract regions from an input simulation model extended to also include SATNUM regions. For relatyive permeability, the scheme keyword can be set to regions_from_simAdds the possibility to extract regions from an existing model. For relative permeability, the scheme key in the config file can be set to 'regions_from_sim'.
+- [#188](https://github.com/equinor/flownet/pull/188) The possibility to extract regions from an input simulation model extended to also include SATNUM regions. For relative permeability, the scheme keyword can be set to regions_from_sim.
 
 ## [0.3.0] - 2020-09-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
-
 - [#188](https://github.com/equinor/flownet/pull/188) The possibility to extract regions from an input simulation model extended to also include SATNUM regions. For relative permeability, the scheme keyword can be set to 'regions_from_sim' in the configuration file.
 - [#189](https://github.com/equinor/flownet/pull/189) User can now provide both a _base_ configuration file, and an optional extra configuration file which will be used to override the base settings.
-
 
 ## [0.3.0] - 2020-09-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-No new items yet.
+### Added
+- [#188](https://github.com/equinor/flownet/pull/188) The possibility to extract regions from an input simulation model extended to also include SATNUM regions. For relatyive permeability, the scheme keyword can be set to regions_from_simAdds the possibility to extract regions from an existing model. For relative permeability, the scheme key in the config file can be set to 'regions_from_sim'.
 
 ## [0.3.0] - 2020-09-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
-- [#188](https://github.com/equinor/flownet/pull/188) The possibility to extract regions from an input simulation model extended to also include SATNUM regions. For relative permeability, the scheme keyword can be set to regions_from_sim.
+- [#188](https://github.com/equinor/flownet/pull/188) The possibility to extract regions from an input simulation model extended to also include SATNUM regions. For relative permeability, the scheme keyword can be set to 'regions_from_sim' in the configuration file.
 
 ## [0.3.0] - 2020-09-14
 

--- a/src/flownet/ahm/_run_ahm.py
+++ b/src/flownet/ahm/_run_ahm.py
@@ -33,8 +33,9 @@ def _from_regions_to_flow_tubes(
     The function loops through each cell in all flow tubes, and checks what region the
     corresponding position (cell midpoint) in the data source simulation model has. If different
     cells in one flow tube are located in different regions of the original model, the mode is used.
-    If flow tubes are entirely outside of the data source simulation grid,
-    the region closest to the midpoint of the flow tube is used.
+    If flow tubes are entirely outside of the data source simulation grid, the region of the closest 
+    flow tube which has already been assigned to a region will be used. The distance between two flow
+    tubes is calculated as the distance between the mid points of the two flow tubes.
 
     Args:
         network: FlowNet network instance

--- a/src/flownet/ahm/_run_ahm.py
+++ b/src/flownet/ahm/_run_ahm.py
@@ -63,10 +63,10 @@ def _from_regions_to_flow_tubes(
             df_regions.append(None)
             tube_outside.append(i)
 
-    if tube_outside != []:
+    if tube_outside:
         tube_midpoints = network.get_connection_midpoints()
         candidate_tubes = set(network.grid.model.unique()) - set(tube_outside)
-        while len(tube_outside) > 0:
+        while tube_outside:
             i = tube_outside.pop(0)
             first = True
             for j in candidate_tubes:

--- a/src/flownet/ahm/_run_ahm.py
+++ b/src/flownet/ahm/_run_ahm.py
@@ -49,6 +49,7 @@ def _from_regions_to_flow_tubes(
 
     xyz_mid = network.cell_midpoints
 
+    tube_outside = []
     for i in network.grid.model.unique():
         tube_regions = []
         for j in ti2ci[ti2ci.index == i].values:
@@ -58,24 +59,32 @@ def _from_regions_to_flow_tubes(
         if tube_regions != []:
             df_regions.append(mode(tube_regions).mode.tolist()[0])
         else:
-            tube_midpoint = network.get_connection_midpoints(int(i))
-            dist_to_cell = []
-            for k in range(1, field_data.grid.get_num_active()):
-                cell_midpoint = field_data.grid.get_xyz(active_index=k)
-                dist_to_cell.append(
-                    np.sqrt(
-                        np.square(tube_midpoint[0] - cell_midpoint[0])
-                        + np.square(tube_midpoint[1] - cell_midpoint[1])
-                        + np.square(tube_midpoint[2] - cell_midpoint[2])
-                    )
+            df_regions.append(None)
+            tube_outside.append(i)
+
+    if tube_outside != []:
+        tube_midpoints = network.get_connection_midpoints()
+        candidate_tubes = set(network.grid.model.unique()) - set(tube_outside)
+        while len(tube_outside) > 0:
+            i = tube_outside.pop(0)
+            first = True
+            for j in candidate_tubes:
+                dist_to_tube = np.sqrt(
+                    np.square(tube_midpoints[i][0] - tube_midpoints[j][0])
+                    + np.square(tube_midpoints[i][1] - tube_midpoints[j][1])
+                    + np.square(tube_midpoints[i][2] - tube_midpoints[j][2])
                 )
-            df_regions.append(
-                field_data.init(region_name)[
-                    field_data.grid.get_ijk(
-                        active_index=dist_to_cell.index(min(dist_to_cell))
-                    )
-                ]
-            )
+                if first:
+                    first = False
+                    shortest_dist = dist_to_tube
+                    shortest_index = j
+                elif dist_to_tube < shortest_dist:
+                    shortest_dist = dist_to_tube
+                    shortest_index = j
+
+            df_regions[i] = df_regions[shortest_index]
+            candidate_tubes.add(i)
+
     return df_regions
 
 
@@ -255,6 +264,11 @@ def run_flownet_history_matching(
         df_satnum = pd.DataFrame(
             range(1, len(network.grid.model.unique()) + 1), columns=["SATNUM"]
         )
+    elif config.model_parameters.relative_permeability.scheme == "regions_from_sim":
+        df_satnum = pd.DataFrame(
+            _from_regions_to_flow_tubes(network, field_data, ti2ci, "SATNUM"),
+            columns=["SATNUM"],
+        )
     elif config.model_parameters.relative_permeability.scheme == "global":
         df_satnum = pd.DataFrame(
             [1] * len(network.grid.model.unique()), columns=["SATNUM"]
@@ -265,21 +279,37 @@ def run_flownet_history_matching(
         columns=["parameter", "minimum", "maximum", "loguniform", "satnum"]
     )
 
+    relperm_parameters = config.model_parameters.relative_permeability.regions[
+        0
+    ]._asdict()
+    relperm_parameters.popitem(last=False)
+
     relperm_dict = {
         key: values
-        for key, values in config.model_parameters.relative_permeability._asdict().items()
+        for key, values in relperm_parameters.items()
         if not all(value is None for value in values)
     }
 
-    relperm_parameters = {
-        key: relperm_dict[key] for key in relperm_dict if key != "scheme"
-    }
+    relperm_parameters = {key: relperm_dict[key] for key in relperm_dict if key != "id"}
+
+    defined_satnum_regions = []
+    if config.model_parameters.relative_permeability.scheme == "regions_from_sim":
+        relp_config_satnum = config.model_parameters.relative_permeability.regions
+        for reg in relp_config_satnum:
+            defined_satnum_regions.append(reg.id)
+    else:
+        relp_config_satnum = [config.model_parameters.relative_permeability.regions[0]]
+        defined_satnum_regions.append(None)
 
     for i in np.sort(df_satnum["SATNUM"].unique()):
+        if i in defined_satnum_regions:
+            idx = defined_satnum_regions.index(i)
+        else:
+            idx = defined_satnum_regions.index(None)
         info = [
             relperm_parameters.keys(),
-            [relperm_parameters[key].min for key in relperm_parameters],
-            [relperm_parameters[key].max for key in relperm_parameters],
+            [getattr(relp_config_satnum[idx], key).min for key in relperm_parameters],
+            [getattr(relp_config_satnum[idx], key).max for key in relperm_parameters],
             [False] * len(relperm_parameters),
             [i] * len(relperm_parameters),
         ]

--- a/src/flownet/ahm/_run_ahm.py
+++ b/src/flownet/ahm/_run_ahm.py
@@ -33,7 +33,7 @@ def _from_regions_to_flow_tubes(
     The function loops through each cell in all flow tubes, and checks what region the
     corresponding position (cell midpoint) in the data source simulation model has. If different
     cells in one flow tube are located in different regions of the original model, the mode is used.
-    If flow tubes are entirely outside of the data source simulation grid, the region of the closest 
+    If flow tubes are entirely outside of the data source simulation grid, the region of the closest
     flow tube which has already been assigned to a region will be used. The distance between two flow
     tubes is calculated as the distance between the mid points of the two flow tubes.
 

--- a/src/flownet/ahm/_run_ahm.py
+++ b/src/flownet/ahm/_run_ahm.py
@@ -290,7 +290,7 @@ def run_flownet_history_matching(
         if not all(value is None for value in values)
     }
 
-    relperm_parameters = {key: relperm_dict[key] for key in relperm_dict if key != "id"}
+    relperm_parameters = {key: relperm_dict[key] for key in relperm_dict}
 
     defined_satnum_regions = []
     if config.model_parameters.relative_permeability.scheme == "regions_from_sim":

--- a/src/flownet/config_parser/_config_parser.py
+++ b/src/flownet/config_parser/_config_parser.py
@@ -990,11 +990,13 @@ def parse_config(configuration_file: pathlib.Path) -> ConfigSuite.snapshot:
                     or getattr(satreg, parameter).max is None
                 ):
                     raise ValueError(
-                        f"Ambiguous configuration input: The {parameter} parameter is missing or not properly defined in one of the satnum regions."
+                        f"Ambiguous configuration input: The {parameter} parameter is missing\n"
+                        f"or not properly defined in one of the satnum regions."
                     )
                 if getattr(satreg, parameter).max < getattr(satreg, parameter).min:
                     raise ValueError(
-                        f"Ambiguous configuration input: The {parameter} setting 'max' is higher than the 'min' in one of the satnum regions."
+                        f"Ambiguous configuration input: The {parameter} setting 'max' is higher\n"
+                        f"than the 'min' in one of the satnum regions."
                     )
 
     for parameter in (

--- a/src/flownet/config_parser/_config_parser.py
+++ b/src/flownet/config_parser/_config_parser.py
@@ -435,231 +435,246 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
                                 "'individual' (one set of curves per tube).",
                                 MK.Transformation: _to_lower,
                             },
-                            "swirr": {
-                                MK.Type: types.NamedDict,
+                            "regions": {
+                                MK.Type: types.List,
                                 MK.Content: {
-                                    "min": {
-                                        MK.Type: types.Number,
-                                        MK.AllowNone: True,
-                                    },
-                                    "max": {
-                                        MK.Type: types.Number,
-                                        MK.AllowNone: True,
-                                    },
-                                    "loguniform": {
-                                        MK.Type: types.Bool,
-                                        MK.AllowNone: True,
-                                    },
-                                },
-                            },
-                            "swl": {
-                                MK.Type: types.NamedDict,
-                                MK.Content: {
-                                    "min": {
-                                        MK.Type: types.Number,
-                                        MK.AllowNone: True,
-                                    },
-                                    "max": {
-                                        MK.Type: types.Number,
-                                        MK.AllowNone: True,
-                                    },
-                                    "loguniform": {
-                                        MK.Type: types.Bool,
-                                        MK.AllowNone: True,
-                                    },
-                                },
-                            },
-                            "swcr": {
-                                MK.Type: types.NamedDict,
-                                MK.Content: {
-                                    "min": {
-                                        MK.Type: types.Number,
-                                        MK.AllowNone: True,
-                                    },
-                                    "max": {
-                                        MK.Type: types.Number,
-                                        MK.AllowNone: True,
-                                    },
-                                    "loguniform": {
-                                        MK.Type: types.Bool,
-                                        MK.AllowNone: True,
-                                    },
-                                },
-                            },
-                            "sorw": {
-                                MK.Type: types.NamedDict,
-                                MK.Content: {
-                                    "min": {MK.Type: types.Number},
-                                    "max": {MK.Type: types.Number},
-                                    "loguniform": {
-                                        MK.Type: types.Bool,
-                                        MK.AllowNone: True,
-                                    },
-                                },
-                            },
-                            "krwend": {
-                                MK.Type: types.NamedDict,
-                                MK.Content: {
-                                    "min": {
-                                        MK.Type: types.Number,
-                                        MK.AllowNone: True,
-                                    },
-                                    "max": {
-                                        MK.Type: types.Number,
-                                        MK.AllowNone: True,
-                                    },
-                                    "loguniform": {
-                                        MK.Type: types.Bool,
-                                        MK.AllowNone: True,
-                                    },
-                                },
-                            },
-                            "krowend": {
-                                MK.Type: types.NamedDict,
-                                MK.Content: {
-                                    "min": {
-                                        MK.Type: types.Number,
-                                        MK.AllowNone: True,
-                                    },
-                                    "max": {
-                                        MK.Type: types.Number,
-                                        MK.AllowNone: True,
-                                    },
-                                    "loguniform": {
-                                        MK.Type: types.Bool,
-                                        MK.AllowNone: True,
-                                    },
-                                },
-                            },
-                            "nw": {
-                                MK.Type: types.NamedDict,
-                                MK.Content: {
-                                    "min": {
-                                        MK.Type: types.Number,
-                                        MK.AllowNone: True,
-                                    },
-                                    "max": {
-                                        MK.Type: types.Number,
-                                        MK.AllowNone: True,
-                                    },
-                                    "loguniform": {
-                                        MK.Type: types.Bool,
-                                        MK.AllowNone: True,
-                                    },
-                                },
-                            },
-                            "now": {
-                                MK.Type: types.NamedDict,
-                                MK.Content: {
-                                    "min": {
-                                        MK.Type: types.Number,
-                                        MK.AllowNone: True,
-                                    },
-                                    "max": {
-                                        MK.Type: types.Number,
-                                        MK.AllowNone: True,
-                                    },
-                                    "loguniform": {
-                                        MK.Type: types.Bool,
-                                        MK.AllowNone: True,
-                                    },
-                                },
-                            },
-                            "sorg": {
-                                MK.Type: types.NamedDict,
-                                MK.Content: {
-                                    "min": {
-                                        MK.Type: types.Number,
-                                        MK.AllowNone: True,
-                                    },
-                                    "max": {
-                                        MK.Type: types.Number,
-                                        MK.AllowNone: True,
-                                    },
-                                    "loguniform": {
-                                        MK.Type: types.Bool,
-                                        MK.AllowNone: True,
-                                    },
-                                },
-                            },
-                            "sgcr": {
-                                MK.Type: types.NamedDict,
-                                MK.Content: {
-                                    "min": {
-                                        MK.Type: types.Number,
-                                        MK.AllowNone: True,
-                                    },
-                                    "max": {
-                                        MK.Type: types.Number,
-                                        MK.AllowNone: True,
-                                    },
-                                    "loguniform": {
-                                        MK.Type: types.Bool,
-                                        MK.AllowNone: True,
-                                    },
-                                },
-                            },
-                            "ng": {
-                                MK.Type: types.NamedDict,
-                                MK.Content: {
-                                    "min": {
-                                        MK.Type: types.Number,
-                                        MK.AllowNone: True,
-                                    },
-                                    "max": {
-                                        MK.Type: types.Number,
-                                        MK.AllowNone: True,
-                                    },
-                                },
-                            },
-                            "nog": {
-                                MK.Type: types.NamedDict,
-                                MK.Content: {
-                                    "min": {
-                                        MK.Type: types.Number,
-                                        MK.AllowNone: True,
-                                    },
-                                    "max": {
-                                        MK.Type: types.Number,
-                                        MK.AllowNone: True,
-                                    },
-                                    "loguniform": {
-                                        MK.Type: types.Bool,
-                                        MK.AllowNone: True,
-                                    },
-                                },
-                            },
-                            "krgend": {
-                                MK.Type: types.NamedDict,
-                                MK.Content: {
-                                    "min": {
-                                        MK.Type: types.Number,
-                                        MK.AllowNone: True,
-                                    },
-                                    "max": {
-                                        MK.Type: types.Number,
-                                        MK.AllowNone: True,
-                                    },
-                                    "loguniform": {
-                                        MK.Type: types.Bool,
-                                        MK.AllowNone: True,
-                                    },
-                                },
-                            },
-                            "krogend": {
-                                MK.Type: types.NamedDict,
-                                MK.Content: {
-                                    "min": {
-                                        MK.Type: types.Number,
-                                        MK.AllowNone: True,
-                                    },
-                                    "max": {
-                                        MK.Type: types.Number,
-                                        MK.AllowNone: True,
-                                    },
-                                    "loguniform": {
-                                        MK.Type: types.Bool,
-                                        MK.AllowNone: True,
+                                    MK.Item: {
+                                        MK.Type: types.NamedDict,
+                                        MK.Content: {
+                                            "id": {
+                                                MK.Type: types.Number,
+                                                MK.AllowNone: True,
+                                                MK.Transformation: _none_to_none,
+                                            },
+                                            "swirr": {
+                                                MK.Type: types.NamedDict,
+                                                MK.Content: {
+                                                    "min": {
+                                                        MK.Type: types.Number,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                    "max": {
+                                                        MK.Type: types.Number,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                    "loguniform": {
+                                                        MK.Type: types.Bool,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                },
+                                            },
+                                            "swl": {
+                                                MK.Type: types.NamedDict,
+                                                MK.Content: {
+                                                    "min": {
+                                                        MK.Type: types.Number,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                    "max": {
+                                                        MK.Type: types.Number,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                    "loguniform": {
+                                                        MK.Type: types.Bool,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                },
+                                            },
+                                            "swcr": {
+                                                MK.Type: types.NamedDict,
+                                                MK.Content: {
+                                                    "min": {
+                                                        MK.Type: types.Number,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                    "max": {
+                                                        MK.Type: types.Number,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                    "loguniform": {
+                                                        MK.Type: types.Bool,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                },
+                                            },
+                                            "sorw": {
+                                                MK.Type: types.NamedDict,
+                                                MK.Content: {
+                                                    "min": {MK.Type: types.Number},
+                                                    "max": {MK.Type: types.Number},
+                                                    "loguniform": {
+                                                        MK.Type: types.Bool,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                },
+                                            },
+                                            "krwend": {
+                                                MK.Type: types.NamedDict,
+                                                MK.Content: {
+                                                    "min": {
+                                                        MK.Type: types.Number,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                    "max": {
+                                                        MK.Type: types.Number,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                    "loguniform": {
+                                                        MK.Type: types.Bool,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                },
+                                            },
+                                            "krowend": {
+                                                MK.Type: types.NamedDict,
+                                                MK.Content: {
+                                                    "min": {
+                                                        MK.Type: types.Number,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                    "max": {
+                                                        MK.Type: types.Number,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                    "loguniform": {
+                                                        MK.Type: types.Bool,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                },
+                                            },
+                                            "nw": {
+                                                MK.Type: types.NamedDict,
+                                                MK.Content: {
+                                                    "min": {
+                                                        MK.Type: types.Number,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                    "max": {
+                                                        MK.Type: types.Number,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                    "loguniform": {
+                                                        MK.Type: types.Bool,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                },
+                                            },
+                                            "now": {
+                                                MK.Type: types.NamedDict,
+                                                MK.Content: {
+                                                    "min": {
+                                                        MK.Type: types.Number,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                    "max": {
+                                                        MK.Type: types.Number,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                    "loguniform": {
+                                                        MK.Type: types.Bool,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                },
+                                            },
+                                            "sorg": {
+                                                MK.Type: types.NamedDict,
+                                                MK.Content: {
+                                                    "min": {
+                                                        MK.Type: types.Number,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                    "max": {
+                                                        MK.Type: types.Number,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                    "loguniform": {
+                                                        MK.Type: types.Bool,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                },
+                                            },
+                                            "sgcr": {
+                                                MK.Type: types.NamedDict,
+                                                MK.Content: {
+                                                    "min": {
+                                                        MK.Type: types.Number,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                    "max": {
+                                                        MK.Type: types.Number,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                    "loguniform": {
+                                                        MK.Type: types.Bool,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                },
+                                            },
+                                            "ng": {
+                                                MK.Type: types.NamedDict,
+                                                MK.Content: {
+                                                    "min": {
+                                                        MK.Type: types.Number,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                    "max": {
+                                                        MK.Type: types.Number,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                },
+                                            },
+                                            "nog": {
+                                                MK.Type: types.NamedDict,
+                                                MK.Content: {
+                                                    "min": {
+                                                        MK.Type: types.Number,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                    "max": {
+                                                        MK.Type: types.Number,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                    "loguniform": {
+                                                        MK.Type: types.Bool,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                },
+                                            },
+                                            "krgend": {
+                                                MK.Type: types.NamedDict,
+                                                MK.Content: {
+                                                    "min": {
+                                                        MK.Type: types.Number,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                    "max": {
+                                                        MK.Type: types.Number,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                    "loguniform": {
+                                                        MK.Type: types.Bool,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                },
+                                            },
+                                            "krogend": {
+                                                MK.Type: types.NamedDict,
+                                                MK.Content: {
+                                                    "min": {
+                                                        MK.Type: types.Number,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                    "max": {
+                                                        MK.Type: types.Number,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                    "loguniform": {
+                                                        MK.Type: types.Bool,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                },
+                                            },
+                                        },
                                     },
                                 },
                             },
@@ -849,7 +864,7 @@ def parse_config(configuration_file: pathlib.Path) -> ConfigSuite.snapshot:
         and config.model_parameters.equil.scheme != "global"
     ):
         raise ValueError(
-            f"The relative permeability scheme "
+            f"The equil scheme "
             f"'{config.model_parameters.equil.scheme}' is not valid.\n"
             f"Valid options are 'global', 'regions_from_sim' or 'individual'."
         )
@@ -960,40 +975,39 @@ def parse_config(configuration_file: pathlib.Path) -> ConfigSuite.snapshot:
                 != "global"
                 and getattr(config.model_parameters.relative_permeability, parameter)
                 != "individual"
+                and getattr(config.model_parameters.relative_permeability, parameter)
+                != "regions_from_sim"
             ):
                 raise ValueError(
                     f"The relative permeability scheme "
                     f"'{config.model_parameters.relative_permeability.scheme}' is not valid.\n"
-                    f"Valid options are 'global' or 'individual'."
+                    f"Valid options are 'global', 'regions_from_sim' or 'individual'."
                 )
         else:
-            if (
-                getattr(config.model_parameters.relative_permeability, parameter).min
-                is None
-                or getattr(config.model_parameters.relative_permeability, parameter).max
-                is None
-            ):
-                raise ValueError(
-                    f"Ambiguous configuration input: The {parameter} parameter is missing or not properly defined."
-                )
-            if (
-                getattr(config.model_parameters.relative_permeability, parameter).max
-                < getattr(config.model_parameters.relative_permeability, parameter).min
-            ):
-                raise ValueError(
-                    f"Ambiguous configuration input: The {parameter} setting 'max' is higher than the 'min'"
-                )
+            for satreg in config.model_parameters.relative_permeability.regions:
+                if (
+                    getattr(satreg, parameter).min is None
+                    or getattr(satreg, parameter).max is None
+                ):
+                    raise ValueError(
+                        f"Ambiguous configuration input: The {parameter} parameter is missing or not properly defined in one of the satnum regions."
+                    )
+                if getattr(satreg, parameter).max < getattr(satreg, parameter).min:
+                    raise ValueError(
+                        f"Ambiguous configuration input: The {parameter} setting 'max' is higher than the 'min' in one of the satnum regions."
+                    )
 
-    for parameter in set(config.model_parameters.relative_permeability._fields) - set(
-        req_relp_parameters
+    for parameter in (
+        set(config.model_parameters.relative_permeability.regions[0]._fields)
+        - set(req_relp_parameters)
+        - set(["id"])
     ):
-        if (
-            getattr(config.model_parameters.relative_permeability, parameter).min
-            is not None
-            and getattr(config.model_parameters.relative_permeability, parameter).max
-            is not None
-        ):
-            raise ValueError(f"The {parameter} parameter should not be specified.")
+        for satreg in config.model_parameters.relative_permeability.regions:
+            if (
+                getattr(satreg, parameter).min is not None
+                and getattr(satreg, parameter).max is not None
+            ):
+                raise ValueError(f"The {parameter} parameter should not be specified.")
 
     if config.ert.queue.system.upper() != "LOCAL" and (
         config.ert.queue.name is None or config.ert.queue.server is None


### PR DESCRIPTION
PR #160 closed using EQLNUM regions from source model, this PR deals with using source model SATNUM regions.

For models where many flow tubes end up outside of the source model simulation grid, looping through all cells to find the closest region can be time consuming. Changed here to find the closest flow tube allready assigned a region, which is much faster (and close to the same).

---

### Contributor checklist

- [x] :tada: This PR closes the last part of #139 
- [x] :scroll: I have broken down my PR into the following tasks:
   - [x] Extract SATNUM regions from input simulation and assign regions to flow tubes
   - [x] Testing
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have considered adding a new entry in `CHANGELOG.md`.
- [ ] :books: I have considered updating the documentation.