### PR TITLE
Recursive merge configs

### DIFF
--- a/.github/workflows/flownet.yml
+++ b/.github/workflows/flownet.yml
@@ -84,9 +84,10 @@ jobs:
       - name: 🚀 Run full FlowNet example
         run: |
           source $VENV_PATH/bin/activate
-          flownet ahm ./flownet-testdata/${{ matrix.flownet-model }}/ci_config/assisted_history_matching.yml ./some_ahm_run
-          flownet pred ./flownet-testdata/${{ matrix.flownet-model }}/ci_config/prediction.yml ./some_pred_run ./some_ahm_run
-
+          pushd ./flownet-testdata/${{ matrix.flownet-model }}
+          flownet ahm ./config/assisted_history_matching.yml ./some_ahm_run --update-config ./ci_config/assisted_history_matching.yml
+          flownet pred ./config/prediction.yml ./some_pred_run ./some_ahm_run  --update-config ./ci_config/prediction.yml
+          popd
       - name: 📚 Build documentation
         run: |
           source $VENV_PATH/bin/activate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-No new items yet.
+### Added
+- [#189](https://github.com/equinor/flownet/pull/189) User can now provide both a _base_ configuration file, and an optional extra configuration file
+which will be used to override the base settings.
 
 ## [0.3.0] - 2020-09-14
 

--- a/src/flownet/_command_line.py
+++ b/src/flownet/_command_line.py
@@ -64,7 +64,7 @@ def flownet_ahm(args: argparse.Namespace) -> None:
                 f"{args.output_folder} already exists. Add --overwrite or change output folder."
             )
 
-    config = parse_config(args.config)
+    config = parse_config(args.config, args.update_config)
     run_flownet_history_matching(config, args)
 
     if not args.skip_postprocessing:
@@ -90,7 +90,7 @@ def flownet_pred(args: argparse.Namespace) -> None:
                 f"{args.output_folder} already exists. Add --overwrite or change output folder."
             )
 
-    config = parse_pred_config(args.config)
+    config = parse_pred_config(args.config, args.update_config)
     run_flownet_prediction(config, args)
 
     if not args.skip_postprocessing:
@@ -138,6 +138,13 @@ def main():
         "output_folder", type=pathlib.Path, help="Folder to store AHM output."
     )
     parser_ahm.add_argument(
+        "--update-config",
+        type=pathlib.Path,
+        default=None,
+        help="Optional configuration file which values will update the main config. "
+        "Any relative paths in this file will also be assumed relative to the main config.",
+    )
+    parser_ahm.add_argument(
         "--overwrite",
         action="store_true",
         help="Overwrite output directory if it already exists",
@@ -177,6 +184,12 @@ def main():
         "ahm_folder",
         type=pathlib.Path,
         help="Folder to where the AHM run to be base on is located.",
+    )
+    parser_pred.add_argument(
+        "--update-config",
+        type=pathlib.Path,
+        default=None,
+        help="Optional configuration file which values will update the main config.",
     )
     parser_pred.add_argument(
         "--overwrite",

--- a/src/flownet/config_parser/_config_parser.py
+++ b/src/flownet/config_parser/_config_parser.py
@@ -6,6 +6,7 @@ import yaml
 import configsuite
 from configsuite import types, MetaKeys as MK, ConfigSuite
 
+from ._merge_configs import merge_configs
 from ..data.from_flow import FlowData
 
 
@@ -811,14 +812,18 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
     }
 
 
-def parse_config(configuration_file: pathlib.Path) -> ConfigSuite.snapshot:
+def parse_config(
+    base_config: pathlib.Path, update_config: pathlib.Path = None
+) -> ConfigSuite.snapshot:
     """
     Takes in path to a yaml configuration file, parses it, populates with default values
     where that is defined and the has not provided his/her own value. Also error checks input
     arguments, and making sure they are of expected type.
 
     Args:
-        configuration_file: Path to configuration file.
+        base_cofnig: Path to the main configuration file.
+        update_config: Optional configuration file with
+            key/values to override in main configuration file.
 
     Returns:
         Parsed config, where values can be extracted like e.g. 'config.ert.queue.system'.
@@ -826,11 +831,17 @@ def parse_config(configuration_file: pathlib.Path) -> ConfigSuite.snapshot:
     """
     # pylint: disable=too-many-branches, too-many-statements, too-many-lines
 
-    input_config = yaml.safe_load(configuration_file.read_text())
+    if update_config is None:
+        input_config = yaml.safe_load(base_config.read_text())
+    else:
+        input_config = merge_configs(
+            yaml.safe_load(base_config.read_text()),
+            yaml.safe_load(update_config.read_text()),
+        )
 
     suite = ConfigSuite(
         input_config,
-        create_schema(config_folder=configuration_file.parent),
+        create_schema(config_folder=base_config.parent),
         deduce_required=True,
     )
 

--- a/src/flownet/config_parser/_merge_configs.py
+++ b/src/flownet/config_parser/_merge_configs.py
@@ -1,0 +1,22 @@
+from typing import Dict, Any
+from collections.abc import Mapping
+
+
+def merge_configs(base: Dict[Any, Any], update: Dict[Any, Any]) -> Dict[Any, Any]:
+    """
+    Merges two dictionaries (of arbitrary depth).
+
+    Args:
+        base: Initial dictionary to begin with.
+        update: Dictionary with values to update with.
+
+    Returns:
+        Merged dictionary.
+
+    """
+    for key, value in update.items():
+        if isinstance(value, Mapping):
+            base[key] = merge_configs(base.get(key, {}), value)  # type: ignore
+        else:
+            base[key] = value
+    return base

--- a/tests/test_merge_configs.py
+++ b/tests/test_merge_configs.py
@@ -1,0 +1,17 @@
+from flownet.config_parser._merge_configs import merge_configs
+
+
+def test_merge_configs() -> None:
+
+    base = {
+        "some_key": 42,
+        "some_nested_value": {"a": 1, "b": 2, "c": {"d": 3, "e": 4}},
+    }
+    update = {"some_key": 3, "some_nested_value": {"b": 999, "c": {"e": None}}}
+
+    expected = {
+        "some_key": 3,
+        "some_nested_value": {"a": 1, "b": 999, "c": {"d": 3, "e": None}},
+    }
+
+    assert merge_configs(base, update) == expected


### PR DESCRIPTION
User can now have a _base_ configuration file, and also provide an optional configuration file which will be merged into the base configuration.

---

### Contributor checklist

- [X] :tada: This PR closes #142 and closes #168.
- [X] :scroll: I have broken down my PR into the following tasks:
   - [X] Add a function that recusrively merges dictionaries down to leaves (then being non-dictionaries)
   - [X] Change config parser of AHM and pred to support base and (optional) update config.
   - [X] Add optional update config in commandline entrypoints.
   - [X] Add unit test.
- [X] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have considered adding a new entry in `CHANGELOG.md`.
- [X] :books: I have considered updating the documentation (command line help is updated).