### PR TITLE
Adding possibility to change control modes in history matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- [#220](https://github.com/equinor/flownet/pull/220) User can now provide the historical _control mode_ in the production wells and _control mode_/_target_ in the injection wells. One value for each, applied to all wells.
 - [#199](https://github.com/equinor/flownet/pull/199) Added the possibility of defining a 'base' value for all parameters related to relative permeability. This provides the opportunity to interpolate between three relative permeability models. All the 'min' values will be used to construct a pessimistic or low model, the 'base' values are used for a 'base' model, and the 'high' values are used for an optimistic or high model value. The history matching can then be done with only one (two for three phase models - oil/water and gas/oil interpolated independently) relative permeability parameter(s) per SATNUM region.
 - [#188](https://github.com/equinor/flownet/pull/188) The possibility to extract regions from an input simulation model extended to also include SATNUM regions. For relative permeability, the scheme keyword can be set to 'regions_from_sim' in the configuration file.
 - [#189](https://github.com/equinor/flownet/pull/189) User can now provide both a _base_ configuration file, and an optional extra configuration file which will be used to override the base settings.

--- a/src/flownet/ahm/_run_ahm.py
+++ b/src/flownet/ahm/_run_ahm.py
@@ -343,7 +343,7 @@ def run_flownet_history_matching(
         fault_tolerance=config.flownet.fault_tolerance,
     )
 
-    schedule = Schedule(network, df_production_data, config.name)
+    schedule = Schedule(network, df_production_data, config)
 
     #########################################
     # Set the range on uncertain parameters #

--- a/src/flownet/config_parser/_config_parser.py
+++ b/src/flownet/config_parser/_config_parser.py
@@ -267,17 +267,6 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
                     "max_distance": {MK.Type: types.Number, MK.Default: 1e12},
                     "max_distance_fraction": {MK.Type: types.Number, MK.Default: 0},
                     "default_control_mode": {MK.Type: types.String, MK.Default: "RESV"},
-                    "control_mode_changes": {
-                        MK.Type: types.Dict,
-                        MK.Content: {
-                            MK.Key: {MK.Type: types.Date},
-                            MK.Value: {MK.Type: types.String},
-                        },
-                        MK.Description: "Dictionary with dates as keys and control modes "
-                        "for history matching as values. If defined, this "
-                        "will overwrite the defined default control mode "
-                        "values from the given dates onwards.",
-                    },
                 },
             },
             "ert": {

--- a/src/flownet/config_parser/_config_parser.py
+++ b/src/flownet/config_parser/_config_parser.py
@@ -273,12 +273,11 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
                             MK.Key: {MK.Type: types.Date},
                             MK.Value: {MK.Type: types.String},
                         },
-
                         MK.Description: "Dictionary with dates as keys and control modes "
-                                        "for history matching as values. If defined, this "
-                                        "will overwrite the defined default control mode "
-                                        "values from the given dates onwards."
-                    }
+                        "for history matching as values. If defined, this "
+                        "will overwrite the defined default control mode "
+                        "values from the given dates onwards.",
+                    },
                 },
             },
             "ert": {

--- a/src/flownet/config_parser/_config_parser.py
+++ b/src/flownet/config_parser/_config_parser.py
@@ -266,7 +266,7 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
                     "fault_tolerance": {MK.Type: types.Number, MK.Default: 1.0e-5},
                     "max_distance": {MK.Type: types.Number, MK.Default: 1e12},
                     "max_distance_fraction": {MK.Type: types.Number, MK.Default: 0},
-                    "default_control_mode": {MK.Type: types.String, MK.Default: "RESV"},
+                    "prod_well_control_mode": {MK.Type: types.String, MK.Default: "RESV"},
                 },
             },
             "ert": {

--- a/src/flownet/config_parser/_config_parser.py
+++ b/src/flownet/config_parser/_config_parser.py
@@ -266,7 +266,10 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
                     "fault_tolerance": {MK.Type: types.Number, MK.Default: 1.0e-5},
                     "max_distance": {MK.Type: types.Number, MK.Default: 1e12},
                     "max_distance_fraction": {MK.Type: types.Number, MK.Default: 0},
-                    "prod_well_control_mode": {MK.Type: types.String, MK.Default: "RESV"},
+                    "prod_well_control_mode": {
+                        MK.Type: types.String,
+                        MK.Default: "RESV",
+                    },
                 },
             },
             "ert": {

--- a/src/flownet/config_parser/_config_parser.py
+++ b/src/flownet/config_parser/_config_parser.py
@@ -266,9 +266,13 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
                     "fault_tolerance": {MK.Type: types.Number, MK.Default: 1.0e-5},
                     "max_distance": {MK.Type: types.Number, MK.Default: 1e12},
                     "max_distance_fraction": {MK.Type: types.Number, MK.Default: 0},
-                    "prod_well_control_mode": {
+                    "prod_control_mode": {
                         MK.Type: types.String,
                         MK.Default: "RESV",
+                    },
+                    "inj_control_mode": {
+                        MK.Type: types.String,
+                        MK.Default: "RATE",
                     },
                 },
             },
@@ -932,6 +936,21 @@ def parse_config(
             f"The equil scheme "
             f"'{config.model_parameters.equil.scheme}' is not valid.\n"
             f"Valid options are 'global', 'regions_from_sim' or 'individual'."
+        )
+
+    prod_control_modes = {"ORAT", "GRAT", "WRAT", "LRAT", "RESV", "BHP"}
+    if config.flownet.prod_control_mode not in prod_control_modes:
+        raise ValueError(
+            f"The injection control mode "
+            f"'{config.flownet.prod_control_mode}' is not valid.\n"
+            f"Valid options are {prod_control_modes}. "
+        )
+    inj_control_modes = {"RATE", "BHP"}
+    if config.flownet.inj_control_mode not in inj_control_modes:
+        raise ValueError(
+            f"The injection control mode "
+            f"'{config.flownet.inj_control_mode}' is not valid.\n"
+            f"Valid options are {inj_control_modes}. "
         )
 
     if config.model_parameters.equil.scheme == "regions_from_sim":

--- a/src/flownet/config_parser/_config_parser.py
+++ b/src/flownet/config_parser/_config_parser.py
@@ -266,6 +266,19 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
                     "fault_tolerance": {MK.Type: types.Number, MK.Default: 1.0e-5},
                     "max_distance": {MK.Type: types.Number, MK.Default: 1e12},
                     "max_distance_fraction": {MK.Type: types.Number, MK.Default: 0},
+                    "default_control_mode": {MK.Type: types.String, MK.Default: "RESV"},
+                    "control_mode_changes": {
+                        MK.Type: types.Dict,
+                        MK.Content: {
+                            MK.Key: {MK.Type: types.Date},
+                            MK.Value: {MK.Type: types.String},
+                        },
+
+                        MK.Description: "Dictionary with dates as keys and control modes "
+                                        "for history matching as values. If defined, this "
+                                        "will overwrite the defined default control mode "
+                                        "values from the given dates onwards."
+                    }
                 },
             },
             "ert": {

--- a/src/flownet/realization/_schedule.py
+++ b/src/flownet/realization/_schedule.py
@@ -27,7 +27,8 @@ class Schedule:
         self._schedule_items: List = []
         self._network: NetworkModel = network
         self._df_production_data: pd.DataFrame = df_production_data
-        self._control_mode: str = config.flownet.prod_well_control_mode
+        self._prod_control_mode: str = config.flownet.prod_control_mode
+        self._inj_control_mode: str = config.flownet.inj_control_mode
         self._case_name: str = config.name
         self._create_schedule()
 
@@ -161,7 +162,7 @@ class Schedule:
                         date=value["date"],
                         well_name=value["WELL_NAME"],
                         status=value["WSTAT"],
-                        control_mode=self._control_mode,
+                        control_mode=self._prod_control_mode,
                         vfp_table=vfp_tables[value["WELL_NAME"]],
                         oil_rate=value["WOPR"],
                         water_rate=value["WWPR"],
@@ -196,6 +197,7 @@ class Schedule:
                         rate=value["WWIR"],
                         bhp=value["WBHP"],
                         thp=value["WTHP"],
+                        target=self._inj_control_mode,
                     )
                 )
             elif value["TYPE"] == "GI" and start_date and value["date"] >= start_date:
@@ -208,6 +210,7 @@ class Schedule:
                         rate=value["WGIR"],
                         bhp=value["WBHP"],
                         thp=value["WTHP"],
+                        target=self._inj_control_mode,
                     )
                 )
 

--- a/src/flownet/realization/_schedule.py
+++ b/src/flownet/realization/_schedule.py
@@ -8,7 +8,14 @@ import numpy as np
 import pandas as pd
 
 from configsuite import ConfigSuite
-from ._simulation_keywords import Keyword, COMPDAT, WCONHIST, WCONINJH, WELSPECS, WHISTCTL
+from ._simulation_keywords import (
+    Keyword,
+    COMPDAT,
+    WCONHIST,
+    WCONINJH,
+    WELSPECS,
+    WHISTCTL,
+)
 from ..network_model import NetworkModel
 
 
@@ -27,7 +34,11 @@ class Schedule:
         self._schedule_items: List = []
         self._network: NetworkModel = network
         self._df_production_data: pd.DataFrame = df_production_data
-        self._control_mode: str = config.flownet.default_control_mode if config.flownet.default_control_mode else "RESV"
+        self._control_mode: str = (
+            config.flownet.default_control_mode
+            if config.flownet.default_control_mode
+            else "RESV"
+        )
         self._control_mode_changes: Dict = dict(config.flownet.control_mode_changes)
         self._case_name: str = config.name
 
@@ -140,7 +151,6 @@ class Schedule:
                     f"Skipping WELSPECS for well {well_name} as no positive production or injection data"
                     f" has been supplied."
                 )
-
 
     def _calculate_whistctl(self):
         """

--- a/src/flownet/realization/_schedule.py
+++ b/src/flownet/realization/_schedule.py
@@ -16,6 +16,11 @@ class Schedule:
     """
     Python class to to store all schedule items for the Flownet run.
 
+    Args:
+        network: FlowNet network instance
+        df_production_data: Dataframe with all production data
+        config: Information from the FlowNet config yaml
+
     """
 
     def __init__(
@@ -162,7 +167,7 @@ class Schedule:
                         date=value["date"],
                         well_name=value["WELL_NAME"],
                         status=value["WSTAT"],
-                        control_mode=self._prod_control_mode,
+                        prod_control_mode=self._prod_control_mode,
                         vfp_table=vfp_tables[value["WELL_NAME"]],
                         oil_rate=value["WOPR"],
                         water_rate=value["WWPR"],
@@ -197,7 +202,7 @@ class Schedule:
                         rate=value["WWIR"],
                         bhp=value["WBHP"],
                         thp=value["WTHP"],
-                        target=self._inj_control_mode,
+                        inj_control_mode=self._inj_control_mode,
                     )
                 )
             elif value["TYPE"] == "GI" and start_date and value["date"] >= start_date:
@@ -210,7 +215,7 @@ class Schedule:
                         rate=value["WGIR"],
                         bhp=value["WBHP"],
                         thp=value["WTHP"],
-                        target=self._inj_control_mode,
+                        inj_control_mode=self._inj_control_mode,
                     )
                 )
 

--- a/src/flownet/realization/_schedule.py
+++ b/src/flownet/realization/_schedule.py
@@ -27,8 +27,7 @@ class Schedule:
         self._schedule_items: List = []
         self._network: NetworkModel = network
         self._df_production_data: pd.DataFrame = df_production_data
-        self._control_mode: str = config.flownet.default_control_mode
-        self._control_mode_changes: Dict = dict(config.flownet.control_mode_changes)
+        self._control_mode: str = config.flownet.prod_well_control_mode
         self._case_name: str = config.name
         self._create_schedule()
 

--- a/src/flownet/realization/_schedule.py
+++ b/src/flownet/realization/_schedule.py
@@ -8,14 +8,7 @@ import numpy as np
 import pandas as pd
 
 from configsuite import ConfigSuite
-from ._simulation_keywords import (
-    Keyword,
-    COMPDAT,
-    WCONHIST,
-    WCONINJH,
-    WELSPECS,
-    WHISTCTL,
-)
+from ._simulation_keywords import Keyword, COMPDAT, WCONHIST, WCONINJH, WELSPECS
 from ..network_model import NetworkModel
 
 
@@ -34,14 +27,9 @@ class Schedule:
         self._schedule_items: List = []
         self._network: NetworkModel = network
         self._df_production_data: pd.DataFrame = df_production_data
-        self._control_mode: str = (
-            config.flownet.default_control_mode
-            if config.flownet.default_control_mode
-            else "RESV"
-        )
+        self._control_mode: str = config.flownet.default_control_mode
         self._control_mode_changes: Dict = dict(config.flownet.control_mode_changes)
         self._case_name: str = config.name
-
         self._create_schedule()
 
     def _create_schedule(self):
@@ -54,7 +42,6 @@ class Schedule:
         self._calculate_welspecs()
         self._calculate_wconhist()
         self._calculate_wconinjh()
-        self._calculate_whistctl()
         print("done.", flush=True)
 
     def _calculate_entity_dates(self):
@@ -151,23 +138,6 @@ class Schedule:
                     f"Skipping WELSPECS for well {well_name} as no positive production or injection data"
                     f" has been supplied."
                 )
-
-    def _calculate_whistctl(self):
-        """
-        Helper function that generates the WHISTCTL keywords based on dates/control modes provided in the
-        config yaml file
-
-        Returns:
-            Nothing
-
-        """
-        for key, value in self._control_mode_changes.items():
-            self.append(
-                WHISTCTL(
-                    date=key,
-                    control_mode=value,
-                )
-            )
 
     def _calculate_wconhist(self):
         """
@@ -407,7 +377,7 @@ class Schedule:
                 }
             )
         else:
-            output = list({kw.well_name for kw in self._schedule_items if kw.well_name})
+            output = list({kw.well_name for kw in self._schedule_items})
 
         return output
 
@@ -524,7 +494,7 @@ class Schedule:
         num_training_dates = round(len(self.get_dates()) * training_set_fraction)
         i = 0
 
-        for date in self.get_dates()[0 : num_training_dates - 1]:
+        for date in self.get_dates()[1 : num_training_dates - 1]:
             keywords_wconhist: List[Keyword] = self.get_keywords(
                 date=date, kw_class="WCONHIST"
             )

--- a/src/flownet/realization/_simulation_keywords.py
+++ b/src/flownet/realization/_simulation_keywords.py
@@ -1,5 +1,4 @@
 from abc import ABC
-from typing import Optional
 import datetime
 
 import numpy as np
@@ -13,7 +12,7 @@ class Keyword(ABC):
     """
 
     name: str
-    well_name: Optional[str] = None
+    well_name: str
     oil_rate: float
     gas_rate: float
     bhp: float
@@ -36,25 +35,6 @@ class DATES(Keyword):
     See the OPM Flow manual for further details.
 
     """
-
-
-class WHISTCTL(Keyword):
-    """
-    This keyword overrides the history matching production well control modes, set in all subsequent
-    WCONHIST keywords, with a single specified control mode.
-
-    See the OPM Flow manual for further details
-
-    """
-
-    def __init__(
-        self,
-        date: datetime.date,
-        control_mode: str,
-    ):
-        super().__init__(date)
-        self.name = "WHISTCTL"
-        self.control_mode: str = control_mode
 
 
 class COMPDAT(Keyword):

--- a/src/flownet/realization/_simulation_keywords.py
+++ b/src/flownet/realization/_simulation_keywords.py
@@ -1,4 +1,5 @@
 from abc import ABC
+from typing import Optional
 import datetime
 
 import numpy as np
@@ -12,7 +13,7 @@ class Keyword(ABC):
     """
 
     name: str
-    well_name: str
+    well_name: Optional[str] = None
     oil_rate: float
     gas_rate: float
     bhp: float
@@ -53,7 +54,6 @@ class WHISTCTL(Keyword):
     ):
         super().__init__(date)
         self.name = "WHISTCTL"
-        self.well_name = None
         self.control_mode: str = control_mode
 
 

--- a/src/flownet/realization/_simulation_keywords.py
+++ b/src/flownet/realization/_simulation_keywords.py
@@ -37,6 +37,26 @@ class DATES(Keyword):
     """
 
 
+class WHISTCTL(Keyword):
+    """
+    This keyword overrides the history matching production well control modes, set in all subsequent
+    WCONHIST keywords, with a single specified control mode.
+
+    See the OPM Flow manual for further details
+
+    """
+    def __init__(
+        self,
+        date: datetime.date,
+        control_mode: str,
+    ):
+        super().__init__(date)
+        self.name = "WHISTCTL"
+        self.well_name = None
+        self.control_mode: str = control_mode
+
+
+
 class COMPDAT(Keyword):
     """
     The COMPDAT keyword defines how a well is connected to the reservoir by defining or modifying existing

--- a/src/flownet/realization/_simulation_keywords.py
+++ b/src/flownet/realization/_simulation_keywords.py
@@ -149,7 +149,7 @@ class WCONINJH(Keyword):
         bhp: float = np.nan,
         thp: float = np.nan,
         vfp_table: str = "1*",
-        target: str = "1*",
+        inj_control_mode: str = "1*",
     ):
         super().__init__(date)
         self.name = "WCONINJH"
@@ -160,7 +160,7 @@ class WCONINJH(Keyword):
         self.bhp: float = bhp
         self.thp: float = thp
         self.vfp_table: str = vfp_table
-        self.target: str = target
+        self.inj_control_mode: str = inj_control_mode
 
 
 class WELSPECS(Keyword):

--- a/src/flownet/realization/_simulation_keywords.py
+++ b/src/flownet/realization/_simulation_keywords.py
@@ -45,6 +45,7 @@ class WHISTCTL(Keyword):
     See the OPM Flow manual for further details
 
     """
+
     def __init__(
         self,
         date: datetime.date,
@@ -54,7 +55,6 @@ class WHISTCTL(Keyword):
         self.name = "WHISTCTL"
         self.well_name = None
         self.control_mode: str = control_mode
-
 
 
 class COMPDAT(Keyword):

--- a/src/flownet/realization/_simulation_keywords.py
+++ b/src/flownet/realization/_simulation_keywords.py
@@ -102,7 +102,7 @@ class WCONHIST(Keyword):
         self,
         date: datetime.date,
         well_name: str,
-        control_mode: str,
+        prod_control_mode: str,
         status: str = "1*",
         oil_rate: float = np.nan,
         water_rate: float = np.nan,
@@ -116,7 +116,7 @@ class WCONHIST(Keyword):
         self.name = "WCONHIST"
         self.well_name: str = well_name
         self.status: str = status
-        self.control_mode: str = control_mode
+        self.prod_control_mode: str = prod_control_mode
         self.oil_rate: float = oil_rate
         self.water_rate: float = water_rate
         self.gas_rate: float = gas_rate

--- a/src/flownet/templates/HISTORY_SCHEDULE.inc.jinja2
+++ b/src/flownet/templates/HISTORY_SCHEDULE.inc.jinja2
@@ -29,7 +29,7 @@ WCONHIST
 -- WELL OPEN/ CNTL OIL  WAT  GAS  VFP   VFP  THP  BHP
 -- NAME SHUT  MODE RATE RATE RATE TABLE ALFQ PRES PRES
 {%- for kw in schedule.get_keywords(date=date, kw_class="WCONHIST"): %}
-  '{{ kw.well_name }}' '{{ kw.status }}' '{{ kw.control_mode }}' {{ kw.oil_rate | isnan }} {{ kw.water_rate | isnan }} {{ kw.gas_rate | isnan }} {{ kw.vfp_table }} {{ kw.artificial_lift }} {{ kw.thp | isnan }} {{ kw.bhp | isnan }} /
+  '{{ kw.well_name }}' '{{ kw.status }}' '{{ kw.prod_control_mode }}' {{ kw.oil_rate | isnan }} {{ kw.water_rate | isnan }} {{ kw.gas_rate | isnan }} {{ kw.vfp_table }} {{ kw.artificial_lift }} {{ kw.thp | isnan }} {{ kw.bhp | isnan }} /
 {%- endfor %}
 /
 {%- endif %}
@@ -39,7 +39,7 @@ WCONINJH
 -- WELL FLUID OPEN/ SURF BHP   THP  VFP   4 NOT TAR
 -- NAME TYPE  SHUT  RATE PRSES PRES TABLE USED  GET
 {%- for kw in schedule.get_keywords(date=date, kw_class="WCONINJH"): %}
- '{{ kw.well_name }}' '{{ kw.inj_type }}' '{{ kw.status }}' {{ kw.rate | isnan }} {{ kw.bhp | isnan }} {{ kw.thp | isnan }} {{ kw.vfp_table }} 4* '{{ kw.target }}' /
+ '{{ kw.well_name }}' '{{ kw.inj_type }}' '{{ kw.status }}' {{ kw.rate | isnan }} {{ kw.bhp | isnan }} {{ kw.thp | isnan }} {{ kw.vfp_table }} 4* '{{ kw.inj_control_mode }}' /
 {%- endfor %}
 /
 

--- a/src/flownet/templates/HISTORY_SCHEDULE.inc.jinja2
+++ b/src/flownet/templates/HISTORY_SCHEDULE.inc.jinja2
@@ -4,6 +4,14 @@ DATES
  {{ date.strftime('%d %b %Y').upper() }} /
 /
 {%- endif %}
+
+{%- if schedule.get_keywords(date=date, kw_class="WHISTCTL"): %}
+WHISTCTL
+{%- for kw in schedule.get_keywords(date=date, kw_class="WHISTCTL"): %}
+  {{  kw.control_mode.upper()  }} /
+{%- endfor %}
+{%- endif %}
+
 {%- if schedule.get_keywords(date=date, kw_class="WELSPECS"): %}
 WELSPECS
 -- WELL GROUP LOCATION BHP   PHASE DRAIN INFLOW OPEN CROSS PVT   DEN FIPNUM

--- a/src/flownet/templates/HISTORY_SCHEDULE.inc.jinja2
+++ b/src/flownet/templates/HISTORY_SCHEDULE.inc.jinja2
@@ -39,7 +39,7 @@ WCONINJH
 -- WELL FLUID OPEN/ SURF BHP   THP  VFP   4 NOT TAR
 -- NAME TYPE  SHUT  RATE PRSES PRES TABLE USED  GET
 {%- for kw in schedule.get_keywords(date=date, kw_class="WCONINJH"): %}
- '{{ kw.well_name }}' '{{ kw.inj_type }}' '{{ kw.status }}' {{ kw.rate | isnan }} {{ kw.bhp | isnan }} {{ kw.thp | isnan }} {{ kw.vfp_table }} 4* {{ kw.target }} /
+ '{{ kw.well_name }}' '{{ kw.inj_type }}' '{{ kw.status }}' {{ kw.rate | isnan }} {{ kw.bhp | isnan }} {{ kw.thp | isnan }} {{ kw.vfp_table }} 4* '{{ kw.target }}' /
 {%- endfor %}
 /
 

--- a/src/flownet/templates/HISTORY_SCHEDULE.inc.jinja2
+++ b/src/flownet/templates/HISTORY_SCHEDULE.inc.jinja2
@@ -4,14 +4,6 @@ DATES
  {{ date.strftime('%d %b %Y').upper() }} /
 /
 {%- endif %}
-
-{%- if schedule.get_keywords(date=date, kw_class="WHISTCTL"): %}
-WHISTCTL
-{%- for kw in schedule.get_keywords(date=date, kw_class="WHISTCTL"): %}
-  {{  kw.control_mode.upper()  }} /
-{%- endfor %}
-{%- endif %}
-
 {%- if schedule.get_keywords(date=date, kw_class="WELSPECS"): %}
 WELSPECS
 -- WELL GROUP LOCATION BHP   PHASE DRAIN INFLOW OPEN CROSS PVT   DEN FIPNUM

--- a/src/flownet/templates/observations.ertobs.jinja2
+++ b/src/flownet/templates/observations.ertobs.jinja2
@@ -1,9 +1,7 @@
-{%- for date in schedule.get_dates()[0:num_training_dates-1] -%}
+{%- for date in schedule.get_dates()[1:num_training_dates-1] -%}
 
 {%- if schedule.get_keywords(date=date, kw_class="WCONHIST"): %}
 {%- for kw in schedule.get_keywords(date=date, kw_class="WCONHIST"): -%}
-
-{%- if not schedule.get_well_start_date(kw.well_name) == date: %}
 
 {%- set index_name = date.strftime('%d_%m_%Y') -%}
 {%- set date_formatted = date.strftime('%d/%m/%Y') %}
@@ -24,15 +22,11 @@ SUMMARY_OBSERVATION WBHP_{{ kw.well_name }}_{{ index_name }} { VALUE = {{ kw.bhp
 SUMMARY_OBSERVATION WTHP_{{ kw.well_name }}_{{ index_name }} { VALUE = {{ kw.thp }}; ERROR = {{ [error_config.WTHP.rel_error * kw.thp, error_config.WTHP.min_error] | max }}; DATE = {{ date_formatted  }}; KEY = WTHP:{{ kw.well_name }}; };
 {%- endif %}
 
-{%- endif %}
-
 {% endfor %}
 {%- endif %}
 
 {%- if schedule.get_keywords(date=date, kw_class="WCONINJH"): %}
 {%- for kw in schedule.get_keywords(date=date, kw_class="WCONINJH"): -%}
-
-{%- if not schedule.get_well_start_date(kw.well_name) == date: %}
 
 {%- set index_name = date.strftime('%d_%m_%Y') -%}
 {%- set date_formatted = date.strftime('%d/%m/%Y') %}
@@ -48,7 +42,6 @@ SUMMARY_OBSERVATION WGIR_{{ kw.well_name }}_{{ index_name }} { VALUE = {{ kw.rat
 {%- endif %}
 {%- if not isnan(kw.rate) and kw.inj_type == "WATER" and error_config.WWIR.rel_error is not none and error_config.WWIR.min_error is not none: %}
 SUMMARY_OBSERVATION WWIR_{{ kw.well_name }}_{{ index_name }} { VALUE = {{ kw.rate }}; ERROR = {{ [error_config.WWIR.rel_error * kw.rate, error_config.WWIR.min_error] | max }}; DATE = {{ date_formatted  }}; KEY = WWIR:{{ kw.well_name }}; };
-{%- endif %}
 {%- endif %}
 
 {% endfor %}


### PR DESCRIPTION
Adding the possibility to change how the production wells are controlled in the WCONHIST keywords. This will not be controlled by one keyword in the config yaml.

---

### Contributor checklist

- [x] :tada: This PR closes #219 
- [x] :scroll: I have broken down my PR into the following tasks:
   - [x] Setting keyword for control mode in WCONHIST and WCONINJH in the config yaml
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have considered adding a new entry in `CHANGELOG.md`.
- [ ] :books: I have considered updating the documentation.