### PR TITLE
Generating low/base/high SCAL recommendations for pyscal

### DIFF
--- a/src/flownet/ahm/_run_ahm.py
+++ b/src/flownet/ahm/_run_ahm.py
@@ -566,7 +566,11 @@ def run_flownet_history_matching(
                 for key in relperm_parameters
             ]
             for i, item in enumerate(low_optimistic):
-                if item: interp_info[0][i], interp_info[2][i] = interp_info[2][i], interp_info[0][i]
+                if item:
+                    interp_info[0][i], interp_info[2][i] = (
+                        interp_info[2][i],
+                        interp_info[0][i],
+                    )
 
             info: List = [["interpolate"], [-1], [1], [False], [i]]
             if {"oil", "gas", "water"}.issubset(config.flownet.phases):

--- a/src/flownet/ahm/_run_ahm.py
+++ b/src/flownet/ahm/_run_ahm.py
@@ -561,6 +561,13 @@ def run_flownet_history_matching(
                 + ["high"]
                 + [i],
             ]
+            low_optimistic = [
+                getattr(relp_config_satnum[idx], key).low_optimistic
+                for key in relperm_parameters
+            ]
+            for i, item in enumerate(low_optimistic):
+                if item: interp_info[0][i], interp_info[2][i] = interp_info[2][i], interp_info[0][i]
+
             info: List = [["interpolate"], [-1], [1], [False], [i]]
             if {"oil", "gas", "water"}.issubset(config.flownet.phases):
                 add_info = ["interpolate gas", -1, 1, False, i]

--- a/src/flownet/ahm/_run_ahm.py
+++ b/src/flownet/ahm/_run_ahm.py
@@ -565,11 +565,11 @@ def run_flownet_history_matching(
                 getattr(relp_config_satnum[idx], key).low_optimistic
                 for key in relperm_parameters
             ]
-            for i, item in enumerate(low_optimistic):
-                if item:
-                    interp_info[0][i], interp_info[2][i] = (
-                        interp_info[2][i],
-                        interp_info[0][i],
+            for j, val in enumerate(low_optimistic):
+                if val:
+                    interp_info[0][j], interp_info[2][j] = (
+                        interp_info[2][j],
+                        interp_info[0][j],
                     )
 
             info: List = [["interpolate"], [-1], [1], [False], [i]]

--- a/src/flownet/ahm/_run_ahm.py
+++ b/src/flownet/ahm/_run_ahm.py
@@ -512,11 +512,12 @@ def run_flownet_history_matching(
     ]._asdict()
     relperm_parameters.pop("id", None)
 
-    relperm_dict = {
-        key: values
-        for key, values in relperm_parameters.items()
-        if not all(value is None for value in values)
-    }
+    relperm_dict = {}
+    for key, values in relperm_parameters.items():
+        values = values._asdict()
+        values.pop("low_optimistic", None)
+        if not all(value is None for _, value in values.items()):
+            relperm_dict[key] = values
 
     relperm_parameters = {key: relperm_dict[key] for key in relperm_dict}
 

--- a/src/flownet/config_parser/_config_parser.py
+++ b/src/flownet/config_parser/_config_parser.py
@@ -552,7 +552,7 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
                                                         MK.Description: "This only has effect if interpolation "
                                                         "between low/base/high relative permeability curves is chosen. "
                                                         "If 'low_optimistic' is set to True, the minimum value for "
-                                                        "this model parameter will be used to generated the high case "
+                                                        "this model parameter will be used to generate the high case "
                                                         "SCAL recommendation curves, and the maximum value will be "
                                                         "used for the low case SCAL recommendation curves.",
                                                     },

--- a/src/flownet/config_parser/_config_parser.py
+++ b/src/flownet/config_parser/_config_parser.py
@@ -546,6 +546,16 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
                                                         MK.Type: types.Bool,
                                                         MK.AllowNone: True,
                                                     },
+                                                    "low_optimistic": {
+                                                        MK.Type: types.Bool,
+                                                        MK.Default: False,
+                                                        MK.Description: "This only has effect if interpolation "
+                                                        "between low/base/high relative permeability curves is chosen. "
+                                                        "If 'low_optimistic' is set to True, the minimum value for "
+                                                        "this model parameter will be used to generated the high case "
+                                                        "SCAL recommendation curves, and the maximum value will be "
+                                                        "used for the low case SCAL recommendation curves."
+                                                    },
                                                 },
                                             },
                                             "swl": {
@@ -566,6 +576,10 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
                                                     "loguniform": {
                                                         MK.Type: types.Bool,
                                                         MK.AllowNone: True,
+                                                    },
+                                                    "low_optimistic": {
+                                                        MK.Type: types.Bool,
+                                                        MK.Default: False,
                                                     },
                                                 },
                                             },
@@ -588,6 +602,10 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
                                                         MK.Type: types.Bool,
                                                         MK.AllowNone: True,
                                                     },
+                                                    "low_optimistic": {
+                                                        MK.Type: types.Bool,
+                                                        MK.Default: False,
+                                                    },
                                                 },
                                             },
                                             "sorw": {
@@ -608,6 +626,10 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
                                                     "loguniform": {
                                                         MK.Type: types.Bool,
                                                         MK.AllowNone: True,
+                                                    },
+                                                    "low_optimistic": {
+                                                        MK.Type: types.Bool,
+                                                        MK.Default: True,
                                                     },
                                                 },
                                             },
@@ -630,6 +652,10 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
                                                         MK.Type: types.Bool,
                                                         MK.AllowNone: True,
                                                     },
+                                                    "low_optimistic": {
+                                                        MK.Type: types.Bool,
+                                                        MK.Default: True,
+                                                    },
                                                 },
                                             },
                                             "kroend": {
@@ -650,6 +676,10 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
                                                     "loguniform": {
                                                         MK.Type: types.Bool,
                                                         MK.AllowNone: True,
+                                                    },
+                                                    "low_optimistic": {
+                                                        MK.Type: types.Bool,
+                                                        MK.Default: False,
                                                     },
                                                 },
                                             },
@@ -672,6 +702,10 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
                                                         MK.Type: types.Bool,
                                                         MK.AllowNone: True,
                                                     },
+                                                    "low_optimistic": {
+                                                        MK.Type: types.Bool,
+                                                        MK.Default: False,
+                                                    },
                                                 },
                                             },
                                             "now": {
@@ -692,6 +726,10 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
                                                     "loguniform": {
                                                         MK.Type: types.Bool,
                                                         MK.AllowNone: True,
+                                                    },
+                                                    "low_optimistic": {
+                                                        MK.Type: types.Bool,
+                                                        MK.Default: True,
                                                     },
                                                 },
                                             },
@@ -714,6 +752,10 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
                                                         MK.Type: types.Bool,
                                                         MK.AllowNone: True,
                                                     },
+                                                    "low_optimistic": {
+                                                        MK.Type: types.Bool,
+                                                        MK.Default: True,
+                                                    },
                                                 },
                                             },
                                             "sgcr": {
@@ -735,6 +777,10 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
                                                         MK.Type: types.Bool,
                                                         MK.AllowNone: True,
                                                     },
+                                                    "low_optimistic": {
+                                                        MK.Type: types.Bool,
+                                                        MK.Default: False,
+                                                    },
                                                 },
                                             },
                                             "ng": {
@@ -751,6 +797,14 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
                                                     "max": {
                                                         MK.Type: types.Number,
                                                         MK.AllowNone: True,
+                                                    },
+                                                    "loguniform": {
+                                                        MK.Type: types.Bool,
+                                                        MK.AllowNone: True,
+                                                    },
+                                                    "low_optimistic": {
+                                                        MK.Type: types.Bool,
+                                                        MK.Default: False,
                                                     },
                                                 },
                                             },
@@ -773,6 +827,10 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
                                                         MK.Type: types.Bool,
                                                         MK.AllowNone: True,
                                                     },
+                                                    "low_optimistic": {
+                                                        MK.Type: types.Bool,
+                                                        MK.Default: True,
+                                                    },
                                                 },
                                             },
                                             "krgend": {
@@ -793,6 +851,10 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
                                                     "loguniform": {
                                                         MK.Type: types.Bool,
                                                         MK.AllowNone: True,
+                                                    },
+                                                    "low_optimistic": {
+                                                        MK.Type: types.Bool,
+                                                        MK.Default: True,
                                                     },
                                                 },
                                             },

--- a/src/flownet/config_parser/_config_parser.py
+++ b/src/flownet/config_parser/_config_parser.py
@@ -554,7 +554,7 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
                                                         "If 'low_optimistic' is set to True, the minimum value for "
                                                         "this model parameter will be used to generated the high case "
                                                         "SCAL recommendation curves, and the maximum value will be "
-                                                        "used for the low case SCAL recommendation curves."
+                                                        "used for the low case SCAL recommendation curves.",
                                                     },
                                                 },
                                             },


### PR DESCRIPTION
Currently the low model relative permeability curves for interpolation is created using all minimum values from relative permeability model parameters. This PR adds a boolean to the config file for all relative permeability model parameters, allowing for to define whether the low or high values should be used in generating the low/high relative permeability curves for interpolation

---

### Contributor checklist

- [x] :tada: This PR closes #231 .
- [x] :scroll: I have broken down my PR into the following tasks:
   - [x] Add boolean variable (with default value) to relative permeability model parameters in config file
   - [x] Using boolean variables to construct low/base/high scal recommendation curves
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have considered adding a new entry in `CHANGELOG.md`.
- [ ] :books: I have considered updating the documentation.