### PR TITLE
Fix duplicate names in hyperopt parameters by using full yaml path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## Unreleased
 
 ### Fixes
-- [#256](https://github.com/equinor/flownet/pull/256) Fixes issues with duplicates names in hyperopt by using the full path in yaml for hyperopt parameter names.
+- [#256](https://github.com/equinor/flownet/pull/256) Fixes issues with duplicate names in hyperopt by using the full path in yaml for hyperopt parameter names.
 
 ## [0.4.0] - 2020-11-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to `FlowNet` will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Fixes
+- [#256](https://github.com/equinor/flownet/pull/256) Fixes issues with duplicates names in hyperopt by using the full path in yaml for hyperopt parameter names.
+
 ## [0.4.0] - 2020-11-18
 
 ### Added

--- a/src/flownet/config_parser/_config_parser_hyperparam.py
+++ b/src/flownet/config_parser/_config_parser_hyperparam.py
@@ -62,13 +62,16 @@ def list_hyperparameters_names(
     return hyperparameters
 
 
-def list_hyperparameters(config_dict: dict, hyperparameters: list) -> list:
+def list_hyperparameters(
+    config_dict: dict, hyperparameters: list, in_config: str = ""
+) -> list:
     """List all hyperparameters defined in a yaml configuration file.
 
     Args:
         config_dict: configuration as dictionary
         hyperparameters: list of hyperparameters already found (used for
                          recursive calling of the function.)
+        in_config: path in the config file
 
     Returns:
         Return a list of all hyperparameters in the config.
@@ -76,10 +79,14 @@ def list_hyperparameters(config_dict: dict, hyperparameters: list) -> list:
     """
     for key, value in config_dict.items():
         if isinstance(value, dict):
-            hyperparameters += list_hyperparameters(value, hyperparameters=[])
+            hyperparameters += list_hyperparameters(
+                value, hyperparameters=[], in_config=f"{key}."
+            )
         if isinstance(value, list):
             if value[0] in ["UNIFORM_CHOICE", "UNIFORM", "CHOICE"]:
-                value = create_hyperopt_space(key=key, name=value[0], values=value[1:])
+                value = create_hyperopt_space(
+                    key=f"{in_config}{key}", name=value[0], values=value[1:]
+                )
                 hyperparameters.append(value)
 
     return hyperparameters


### PR DESCRIPTION
*Insert a description of your pull request (PR) here, and check off the boxes below when they are done.*

---

### Contributor checklist

- [x] :tada: This PR closes #250.
- [x] :scroll: I have broken down my PR into the following tasks:
   - [x] Let entire path in yaml file be used as hyperparameter key
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have considered adding a new entry in `CHANGELOG.md`.
- [ ] :books: I have considered updating the documentation.