### PR TITLE
Raise SubprocessError for non-zero returncode of the ERT subprocess

### DIFF
--- a/src/flownet/ert/_run_subprocess.py
+++ b/src/flownet/ert/_run_subprocess.py
@@ -1,6 +1,7 @@
 import glob
 import pathlib
 import subprocess
+from subprocess import SubprocessError
 
 
 def run_ert_subprocess(command: str, cwd: pathlib.Path, runpath: str) -> None:
@@ -39,3 +40,8 @@ def run_ert_subprocess(command: str, cwd: pathlib.Path, runpath: str) -> None:
                 process.terminate()
                 error_files = glob.glob(str(cwd / runpath.replace("%d", "*") / "ERROR"))
                 raise RuntimeError(pathlib.Path(error_files[0]).read_text())
+
+    if process.returncode > 0:
+        raise SubprocessError(
+            "The ERT workflow failed. Check the ERT log for more details."
+        )

--- a/src/flownet/ert/_run_subprocess.py
+++ b/src/flownet/ert/_run_subprocess.py
@@ -41,7 +41,7 @@ def run_ert_subprocess(command: str, cwd: pathlib.Path, runpath: str) -> None:
                 error_files = glob.glob(str(cwd / runpath.replace("%d", "*") / "ERROR"))
                 raise RuntimeError(pathlib.Path(error_files[0]).read_text())
 
-    if process.returncode > 0:
+    if process.returncode != 0:
         raise SubprocessError(
             "The ERT workflow failed. Check the ERT log for more details."
         )

--- a/src/flownet/ert/_run_subprocess.py
+++ b/src/flownet/ert/_run_subprocess.py
@@ -1,7 +1,6 @@
 import glob
 import pathlib
 import subprocess
-from subprocess import SubprocessError
 
 
 def run_ert_subprocess(command: str, cwd: pathlib.Path, runpath: str) -> None:
@@ -42,6 +41,6 @@ def run_ert_subprocess(command: str, cwd: pathlib.Path, runpath: str) -> None:
                 raise RuntimeError(pathlib.Path(error_files[0]).read_text())
 
     if process.returncode != 0:
-        raise SubprocessError(
+        raise subprocess.SubprocessError(
             "The ERT workflow failed. Check the ERT log for more details."
         )


### PR DESCRIPTION
This fix makes sure that when ERT fails, for whatever reason, a `SubprocessError` is raised and mlflow registers the run as a failed run.

---

### Contributor checklist

- [x] :tada: This PR closes #269.
- [x] :scroll: I have broken down my PR into the following tasks:
   - [x] Add raise when returncode > 0
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have considered adding a new entry in `CHANGELOG.md`.
- [x] :books: I have considered updating the documentation.