### PR TITLE
Add timer to kill ERT if no output for 15 minutes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ REQUIREMENTS = [
     "numpy>=1.17",
     "opm>=2020.10",
     "pandas~=1.0",
+    "psutil>=5.7",
     "pyarrow>=0.14",
     "pykrige>=1.5",
     "pyscal~=0.6.1",

--- a/src/flownet/ert/_run_subprocess.py
+++ b/src/flownet/ert/_run_subprocess.py
@@ -1,6 +1,7 @@
 import glob
 import pathlib
 import subprocess
+from subprocess import SubprocessError
 
 
 def run_ert_subprocess(command: str, cwd: pathlib.Path, runpath: str) -> None:
@@ -39,3 +40,8 @@ def run_ert_subprocess(command: str, cwd: pathlib.Path, runpath: str) -> None:
                 process.terminate()
                 error_files = glob.glob(str(cwd / runpath.replace("%d", "*") / "ERROR"))
                 raise RuntimeError(pathlib.Path(error_files[0]).read_text())
+
+    if process.returncode > 0:
+        raise SubprocessError(
+            "The ERT workflow failed. Check the ERT log for more details."
+        )

--- a/src/flownet/ert/_run_subprocess.py
+++ b/src/flownet/ert/_run_subprocess.py
@@ -41,7 +41,7 @@ def run_ert_subprocess(command: str, cwd: pathlib.Path, runpath: str) -> None:
                 error_files = glob.glob(str(cwd / runpath.replace("%d", "*") / "ERROR"))
                 raise RuntimeError(pathlib.Path(error_files[0]).read_text())
 
-    if process.returncode > 0:
+    if process.returncode != 0:
         raise SubprocessError(
             "The ERT workflow failed. Check the ERT log for more details."
         )

--- a/src/flownet/ert/_run_subprocess.py
+++ b/src/flownet/ert/_run_subprocess.py
@@ -14,7 +14,9 @@ def run_ert_subprocess(command: str, cwd: pathlib.Path, runpath: str) -> None:
 
     Should revert here to use the much simpler subprocess.run when
     https://github.com/equinor/libres/issues/984 is closed. See
-    https://github.com/equinor/flownet/pull/119 on changes to revert.
+    https://github.com/equinor/flownet/pull/119, and
+    https://github.com/equinor/flownet/pull/271,
+    on possible changes to revert.
 
     Args:
         command: Command to run.

--- a/src/flownet/ert/_run_subprocess.py
+++ b/src/flownet/ert/_run_subprocess.py
@@ -1,7 +1,6 @@
 import glob
 import pathlib
 import subprocess
-from subprocess import SubprocessError
 
 
 def run_ert_subprocess(command: str, cwd: pathlib.Path, runpath: str) -> None:
@@ -42,6 +41,6 @@ def run_ert_subprocess(command: str, cwd: pathlib.Path, runpath: str) -> None:
                 raise RuntimeError(pathlib.Path(error_files[0]).read_text())
 
     if process.returncode != 0:
-        raise SubprocessError(
+        raise subprocess.SubprocessError(
             "The ERT workflow failed. Check the ERT log for more details."
         )


### PR DESCRIPTION
ERT sometimes hangs, see https://github.com/equinor/libres/issues/984.

This PR adds a timer which, after 15 minutes of complete silence from the ERT process, kills it including all child processes.

---

### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`.
- [ ] :books: I have considered updating the documentation.