### PR TITLE
Change absolute path to relative path for some variables in ERT

### DIFF
--- a/src/flownet/ert/_create_ert_setup.py
+++ b/src/flownet/ert/_create_ert_setup.py
@@ -176,9 +176,9 @@ def create_ert_setup(  # pylint: disable=too-many-arguments
         analysis_quantity = str(None)
 
     configuration = {
-        "pickled_network": output_folder.resolve() / "network.pickled",
-        "pickled_schedule": output_folder.resolve() / "schedule.pickled",
-        "pickled_parameters": output_folder.resolve() / "parameters.pickled",
+        "pickled_network": "../../../../network.pickled",
+        "pickled_schedule":  "../../../../schedule.pickled",
+        "pickled_parameters":  "../../../../parameters.pickled",
         "config": config,
         "random_seed": None,
         "debug": args.debug if hasattr(args, "debug") else False,

--- a/src/flownet/ert/_create_ert_setup.py
+++ b/src/flownet/ert/_create_ert_setup.py
@@ -177,8 +177,8 @@ def create_ert_setup(  # pylint: disable=too-many-arguments
 
     configuration = {
         "pickled_network": "../../../../network.pickled",
-        "pickled_schedule":  "../../../../schedule.pickled",
-        "pickled_parameters":  "../../../../parameters.pickled",
+        "pickled_schedule": "../../../../schedule.pickled",
+        "pickled_parameters": "../../../../parameters.pickled",
         "config": config,
         "random_seed": None,
         "debug": args.debug if hasattr(args, "debug") else False,


### PR DESCRIPTION
When we render each Eclipse/OPM simulation file for each realization we require several file name arguments that are currently absolute paths. 

Each realization is to be render inside `OUTPUT_FOLDER/output/runpath/realization-*/iter-*`, and the files we need to pass as arguments live in OUTPUT_FOLDER/.

I removed the absolute path and include "../../../../" to point towards the corresponding parent directory.

---

### Contributor checklist

- [x] :tada: This PR closes #274.
- [x] :scroll: I have broken down my PR into the following tasks:
   - [x] Change absolute paths to relative path
