### PR TITLE
Pin xrld to <2.0 to avoid version conflixt with semeio

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ REQUIREMENTS = [
     "webviz-config>=0.0.42",
     "webviz-config-equinor>=0.0.9",
     "webviz-subsurface>=0.0.24",
+    "xrld<2",
 ]
 
 TEST_REQUIRES = [

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ REQUIREMENTS = [
     "webviz-config>=0.0.42",
     "webviz-config-equinor>=0.0.9",
     "webviz-subsurface>=0.0.24",
-    "xrld<2",
+    "xlrd<2",
 ]
 
 TEST_REQUIRES = [


### PR DESCRIPTION
Pin `xrld<2` to avoid version conflicts with semeio