### PR TITLE
bug when interpolate relperm is true

### DIFF
--- a/src/flownet/ahm/_run_ahm.py
+++ b/src/flownet/ahm/_run_ahm.py
@@ -560,9 +560,18 @@ def run_flownet_history_matching(
                         interp_info[0][j],
                     )
 
-            info: List = [["interpolate"], [-1], [1], [False], [i]]
+            info: List = [
+                ["interpolate"],
+                [-1],
+                [1],
+                [None],
+                [None],
+                [None],
+                ["uniform"],
+                [i],
+            ]
             if {"oil", "gas", "water"}.issubset(config.flownet.phases):
-                add_info = ["interpolate gas", -1, 1, False, i]
+                add_info = ["interpolate gas", -1, 1, None, None, None, "uniform", i]
                 for j, val in enumerate(add_info):
                     info[j].append(val)
 


### PR DESCRIPTION
PR #251 added distribution parameters. These additional parameters were not accounted for in the generation of a pandas dataframe for the interpolation parameters (always uniform on the interval -1 to 1). Hence, the code failed with an AssertionError when using relative permeability interpolation

---

### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`.
- [ ] :books: I have considered updating the documentation.