### PR TITLE
Update _run_ahm.py

### DIFF
--- a/src/flownet/ahm/_run_ahm.py
+++ b/src/flownet/ahm/_run_ahm.py
@@ -335,9 +335,9 @@ def update_distribution(
                         f"the upper or lower bounds in the prior. This will give a very narrow prior range \n"
                         f"in this run. Consider updating before running again. "
                     )
-            if var.stddev is not None:
+            if var.stddev > 0:
                 stddev = parameter.stddev_values[i]
-                if 0 < stddev / var.stddev < 0.1:
+                if stddev / var.stddev < 0.1:
                     warnings.warn(
                         f"The standard deviation for the posterior ensemble for {parameter.names[i]} is much lower \n"
                         f"than the standard deviation in the prior. This will give a very narrow prior range \n"

--- a/src/flownet/ahm/_run_ahm.py
+++ b/src/flownet/ahm/_run_ahm.py
@@ -326,7 +326,7 @@ def update_distribution(
         for i, var in enumerate(parameter.random_variables):
             mean = parameter.mean_values[i]
             # if mean in posterior is close to min/max in prior raise warning
-            if var.minimum and var.maximum and var.maximum > var.minimum:
+            if var.maximum > var.minimum:
                 if (mean - var.minimum) / (var.mean - var.minimum) < 0.1 or (
                     var.maximum - mean
                 ) / (var.maximum - var.mean) < 0.1:

--- a/src/flownet/ahm/_run_ahm.py
+++ b/src/flownet/ahm/_run_ahm.py
@@ -326,7 +326,7 @@ def update_distribution(
         for i, var in enumerate(parameter.random_variables):
             mean = parameter.mean_values[i]
             # if mean in posterior is close to min/max in prior raise warning
-            if var.minimum and var.maximum:
+            if var.minimum and var.maximum and var.maximum > var.minimum:
                 if (mean - var.minimum) / (var.mean - var.minimum) < 0.1 or (
                     var.maximum - mean
                 ) / (var.maximum - var.mean) < 0.1:

--- a/src/flownet/ahm/_run_ahm.py
+++ b/src/flownet/ahm/_run_ahm.py
@@ -337,7 +337,7 @@ def update_distribution(
                     )
             if var.stddev is not None:
                 stddev = parameter.stddev_values[i]
-                if stddev / var.stddev < 0.1:
+                if 0 < stddev / var.stddev < 0.1:
                     warnings.warn(
                         f"The standard deviation for the posterior ensemble for {parameter.names[i]} is much lower \n"
                         f"than the standard deviation in the prior. This will give a very narrow prior range \n"


### PR DESCRIPTION
The update_distribution function will issue warnings if the posterior used to update the new prior has a narrow range and/or mean close to initial minimum or maximum value. This all breaks down when the parameter is constant... This PR aims to fix this problem.


### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`.
- [ ] :books: I have considered updating the documentation.