### PR TITLE
Fixes bug where the analytics module would fail for iterations > 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changes
 
+## [0.5.1] - 2021-03-03
+
+### Added
+
+### Fixes
+- [#346](https://github.com/equinor/flownet/pull/346) Fixes bug where the analytics module would fail for iterations larger than 9 (i.e., iteration number with two or more digits).
+
+### Changes
+
 ## [0.5.0] - 2021-02-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [0.5.1] - 2021-03-03
 
-### Added
-
 ### Fixes
 - [#346](https://github.com/equinor/flownet/pull/346) Fixes bug where the analytics module would fail for iterations larger than 9 (i.e., iteration number with two or more digits).
-
-### Changes
 
 ## [0.5.0] - 2021-02-26
 

--- a/src/flownet/ahm/_ahm_iteration_analytics.py
+++ b/src/flownet/ahm/_ahm_iteration_analytics.py
@@ -292,7 +292,7 @@ def make_dataframe_simulation_data(
     iteration = sorted(
         [int(rel_iter.replace("/", "").split("-")[-1]) for rel_iter in glob.glob(path)]
     )[-1]
-    runpath_list = glob.glob(path[::-1].replace("*", str(iteration), 1)[::-1])
+    runpath_list = glob.glob(path[::-1].replace("*", str(iteration)[::-1], 1)[::-1])
 
     partial_load_simulations = functools.partial(
         _load_simulations, ecl_base=eclbase_file


### PR DESCRIPTION
*Fixes bug where the analytics module would fail for iterations larger than 9 (i.e., iteration number with two or more digits)*

---

### Contributor checklist

- [x] :tada: This PR closes no open issue.
- [x] :scroll: I have broken down my PR into the following tasks:
   - [x] Fix `make_dataframe_simulation_data` function in `_ahm_iteration_analytics.py`.
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have considered adding a new entry in `CHANGELOG.md`.
- [x] :books: I have considered updating the documentation.