### PR TITLE
Fix memory leak in result plotting script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 ### Fixes
+- [#374](https://github.com/equinor/flownet/pull/374) Fix for memory leak in result plotting script.
 
 ### Changes
 - [#363](https://github.com/equinor/flownet/pull/363) Drop Python 3.6 support.

--- a/src/flownet/utils/plot_results.py
+++ b/src/flownet/utils/plot_results.py
@@ -122,6 +122,7 @@ def plot(
     plt.xlabel("date")
     plt.ylabel(vector + " [" + plot_settings["units"] + "]")
     plt.savefig(re.sub(r"[^\w\-_\. ]", "_", vector), dpi=300)
+    plt.close()
 
 
 def remove_duplicates(df: pd.DataFrame) -> pd.DataFrame:


### PR DESCRIPTION
This PR is a bugfix for a memory leak in the result plotting script.

---

### Contributor checklist

- [x] :tada: This PR closes #373.
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have considered adding a new entry in `CHANGELOG.md`.
- [ ] :books: I have considered updating the documentation.