### PR TITLE
Add delta to SWL to calculate SWCR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## Unreleased
 
 ### Added
+- [#379](https://github.com/equinor/flownet/pull/379) Added option to let SWCR be calculated as SWL + delta, instead of providing the prior distribution for SWCR directly. To do this, set swcr_add_to_swl to true, and then the prior distribution definition in the config yaml for swcr will be interpreted as a prior distribution for the delta value to be added to SWL to get the SWCR.
 - [#372](https://github.com/equinor/flownet/pull/372) Added option to let the additional flownodes initially be placed within the original volume rather than within the convex hull of the real wells. To do this set place_nodes_in_volume_reservoir to true.
 
 ### Fixes

--- a/src/flownet/config_parser/_config_parser.py
+++ b/src/flownet/config_parser/_config_parser.py
@@ -805,7 +805,9 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
                             "swcr_add_to_swl": {
                                 MK.Type: types.Bool,
                                 MK.Description: "Allows for calculating SWCR by adding a number to SWL. Especially useful "
-                                "to avoid non-physical values when defining prior distributions",
+                                "to avoid non-physical values when defining prior distributions. If this parameter is set "
+                                "to true, the numbers defined under swcr will be used to define a prior distribution for "
+                                "the delta value added to SWL, instead of defining the prior distribution for SWCR directly.",
                                 MK.Default: False,
                             },
                             "regions": {

--- a/src/flownet/config_parser/_config_parser.py
+++ b/src/flownet/config_parser/_config_parser.py
@@ -804,10 +804,11 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
                             },
                             "swcr_add_to_swl": {
                                 MK.Type: types.Bool,
-                                MK.Description: "Allows for calculating SWCR by adding a number to SWL. Especially useful "
-                                "to avoid non-physical values when defining prior distributions. If this parameter is set "
-                                "to true, the numbers defined under swcr will be used to define a prior distribution for "
-                                "the delta value added to SWL, instead of defining the prior distribution for SWCR directly.",
+                                MK.Description: "Allows for calculating SWCR by adding a number to SWL. Especially "
+                                "useful to avoid non-physical values when defining prior distributions. If this "
+                                "parameter is set to true, the numbers defined under swcr will be used to define "
+                                "a prior distribution for the delta value added to SWL, instead of defining the "
+                                "prior distribution for SWCR directly.",
                                 MK.Default: False,
                             },
                             "regions": {

--- a/src/flownet/config_parser/_config_parser.py
+++ b/src/flownet/config_parser/_config_parser.py
@@ -802,6 +802,12 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
                                 "per SATNUM region. Only available for three phase problems.",
                                 MK.Default: False,
                             },
+                            "swcr_add_to_swl": {
+                                MK.Type: types.Bool,
+                                MK.Description: "Allows for calculating SWCR by adding a number to SWL. Especially useful "
+                                "to avoid non-physical values when defining prior distributions",
+                                MK.Default: False,
+                            },
                             "regions": {
                                 MK.Type: types.List,
                                 MK.Content: {
@@ -1634,6 +1640,14 @@ def parse_config(
         )
 
     config = suite.snapshot
+    if (
+        config.model_parameters.relative_permeability.interpolate
+        and config.model_parameters.relative_permeability.swcr_add_to_swl
+    ):
+        raise ValueError(
+            "SWCR_ADD_TO_SWL can not be used together with the "
+            "interpolation option for relative permeability."
+        )
 
     # If 'regions_from_sim' is defined, or a csv file with rsvd tables
     # is defined, we need to import the simulation case to check number

--- a/src/flownet/parameters/_relative_permeability.py
+++ b/src/flownet/parameters/_relative_permeability.py
@@ -217,7 +217,9 @@ class RelativePermeability(Parameter):
         self._independent_interpolation = (
             config.model_parameters.relative_permeability.independent_interpolation
         )
-        self._swcr_add_to_swl = config.model_parameters.relative_permeability.swcr_add_to_swl
+        self._swcr_add_to_swl = (
+            config.model_parameters.relative_permeability.swcr_add_to_swl
+        )
 
     def _check_parameters(self) -> Tuple[bool, bool]:
         """

--- a/src/flownet/parameters/_relative_permeability.py
+++ b/src/flownet/parameters/_relative_permeability.py
@@ -217,6 +217,7 @@ class RelativePermeability(Parameter):
         self._independent_interpolation = (
             config.model_parameters.relative_permeability.independent_interpolation
         )
+        self._swcr_add_to_swl = config.model_parameters.relative_permeability.swcr_add_to_swl
 
     def _check_parameters(self) -> Tuple[bool, bool]:
         """
@@ -361,6 +362,8 @@ class RelativePermeability(Parameter):
         else:
             for param in parameters:
                 if self._swof:
+                    if self._swcr_add_to_swl:
+                        param["swcr"] = param["swl"] + param["swcr"]
                     str_swofs += swof_from_parameters(param) + "\n/\n"
                 if self._sgof:
                     str_sgofs += sgof_from_parameters(param) + "\n/\n"


### PR DESCRIPTION
If you want to create a wide range for both SWL and SWCR there is a large chance for generating non-physical values, where SWCR is lower than SWL. This PR adds a parameter to the config yaml (defaulted to false), that provides the opportunity to calculate the SWCR from the SWL by adding a delta value. 

If `swcr_add_to_swcr` is set to `True` the `swcr` parameter in the config yaml will be treated as a prior distribution for the delta value that will be added to SWL, not as a prior distribution for SWCR directly.

---

### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [x] :scroll: I have broken down my PR into the following tasks:
   - [x] Add `swcr_add_to_swl` to config_parser
   - [x] Update render_output for relative_permeability
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have considered adding a new entry in `CHANGELOG.md`.
- [ ] :books: I have considered updating the documentation.