### PR TITLE
Read FlowNet from restart folder pickle files when using restart option

### DIFF
--- a/src/flownet/_command_line.py
+++ b/src/flownet/_command_line.py
@@ -80,6 +80,10 @@ def flownet_ahm(args: argparse.Namespace) -> None:
                 ).is_file()
             ):
                 run_flownet_history_matching_from_restart(config, args)
+            else:
+                raise ValueError(
+                    f"Case in {args.restart_folder} is not complete! Some files are missing!"
+                )
         else:
             raise ValueError(f"{args.restart_folder} does not exist!")
 

--- a/src/flownet/_command_line.py
+++ b/src/flownet/_command_line.py
@@ -5,7 +5,7 @@ import pathlib
 import subprocess
 
 from .config_parser import parse_config, parse_pred_config, parse_hyperparam_config
-from .ahm import run_flownet_history_matching
+from .ahm import run_flownet_history_matching, run_flownet_history_matching_from_restart
 from .prediction import run_flownet_prediction
 from .hyperparameter import run_flownet_hyperparameter
 
@@ -66,7 +66,22 @@ def flownet_ahm(args: argparse.Namespace) -> None:
             )
 
     config = parse_config(args.config, args.update_config)
-    run_flownet_history_matching(config, args)
+    if args.restart_folder is None:
+        run_flownet_history_matching(config, args)
+    else:
+        if args.restart_folder.exists():
+            # check for pickled files and zipped file
+            if (
+                pathlib.Path(args.restart_folder / "network.pickled").is_file()
+                and pathlib.Path(args.restart_folder / "schedule.pickled").is_file()
+                and pathlib.Path(args.restart_folder / "parameters.pickled").is_file()
+                and pathlib.Path(
+                    args.restart_folder / "parameters_iteration-latest.parquet.gzip"
+                ).is_file()
+            ):
+                run_flownet_history_matching_from_restart(config, args)
+        else:
+            raise ValueError(f"{args.restart_folder} does not exist!")
 
     if not args.skip_postprocessing:
         create_webviz(args.output_folder, start_webviz=args.start_webviz)

--- a/src/flownet/ahm/__init__.py
+++ b/src/flownet/ahm/__init__.py
@@ -1,2 +1,5 @@
 from ._assisted_history_matching import AssistedHistoryMatching
-from ._run_ahm import run_flownet_history_matching
+from ._run_ahm import (
+    run_flownet_history_matching,
+    run_flownet_history_matching_from_restart,
+)


### PR DESCRIPTION
There is no need to construct the FlowNet when using the option to define prior distributions from a previously completed run. This PR checks if `network/schedule/parameters.pickle` exists, in addition to the `parameter_iteration-latest.parquet.gzip` file. If the files exists, they are read and a new ERT setup is made based on those.

---

### Contributor checklist

- [ ] :tada: This PR closes #198 .
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Add `run_flownet_history_matching_from_restart `function to `_run_ahm.py`
   - [ ] Add checks in `_command_line.py` to see if `restart_folder `points to an existing case
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`.
- [ ] :books: I have considered updating the documentation.