### PR TITLE
Make EQLNUM regions in FlowNet based on region parameter from simulation model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - [#374](https://github.com/equinor/flownet/pull/374) Fix for memory leak in result plotting script.
 
 ### Changes
-- [#392](https://github.com/equinor/flownet/pull/392) When using scheme regions_from_sim for relative permeability, the user can supply which region to base the generation of FlowNet model's SATNUM parameter on. The default region is SATNUM, but other region parameters (such as FIPNUM or EQLNUM) can be used by setting region_parameter_from_sim_model to e.g. EQLNUM.
+- [#396](https://github.com/equinor/flownet/pull/396) When using scheme regions_from_sim for equilibrium regions, the user can supply which region to base the generation of FlowNet model's EQLNUM parameter on. The default region is EQLNUM, but other region parameters (such as FIPNUM or SATNUM) can be used by setting region_parameter_from_sim_model for equil in the config yaml file.
+- [#392](https://github.com/equinor/flownet/pull/392) When using scheme regions_from_sim for relative permeability, the user can supply which region to base the generation of FlowNet model's SATNUM parameter on. The default region is SATNUM, but other region parameters (such as FIPNUM or EQLNUM) can be used by setting region_parameter_from_sim_model for relative permeability in the config yaml file to e.g. EQLNUM.
 - [#383](https://github.com/equinor/flownet/pull/383) KRWMAX now defaulted to 1, but exposed to used. Previously it was hard coded to 1.
 - [#386](https://github.com/equinor/flownet/pull/386) Increase default timeout from 900 s to 3600 s.
 - [#363](https://github.com/equinor/flownet/pull/363) Drop Python 3.6 support.

--- a/src/flownet/ahm/_run_ahm.py
+++ b/src/flownet/ahm/_run_ahm.py
@@ -711,7 +711,12 @@ def run_flownet_history_matching(
         )
     elif config.model_parameters.equil.scheme == "regions_from_sim":
         df_eqlnum = pd.DataFrame(
-            _from_regions_to_flow_tubes(network, field_data, ti2ci, "EQLNUM"),
+            _from_regions_to_flow_tubes(
+                network,
+                field_data,
+                ti2ci,
+                config.model_parameters.equil.region_parameter_from_sim_model,
+            ),
             columns=["EQLNUM"],
         )
     elif config.model_parameters.equil.scheme == "global":


### PR DESCRIPTION
When setting the scheme to regions_from_sim the EQLNUM regions in the input simulation model were used to generate the EQLNUM regions for the FlowNet model. This PR makes this more flexible by allowing any region parameter from the INIT file to be used.

---

### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [x] :scroll: I have broken down my PR into the following tasks:
   - [x] Add region_parameter_from_sim_model to config_parser.py for equil
   - [x] Add checks to config_parser.py
   - [x] Change the generation of EQLNUM regions for FLOWNET to use the `region_parameter_from_sim_model` instead of the previously hard coded EQLNUM
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have considered adding a new entry in `CHANGELOG.md`.
- [ ] :books: I have considered updating the documentation.