### PR TITLE
Solve deprecation warning: remove .Required in config parser

### DIFF
--- a/src/flownet/config_parser/_config_parser.py
+++ b/src/flownet/config_parser/_config_parser.py
@@ -117,12 +117,10 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
                                                 MK.Content: {
                                                     "rel_error": {
                                                         MK.Type: types.Number,
-                                                        MK.Required: False,
                                                         MK.AllowNone: True,
                                                     },
                                                     "min_error": {
                                                         MK.Type: types.Number,
-                                                        MK.Required: False,
                                                         MK.AllowNone: True,
                                                     },
                                                 },
@@ -132,12 +130,10 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
                                                 MK.Content: {
                                                     "rel_error": {
                                                         MK.Type: types.Number,
-                                                        MK.Required: False,
                                                         MK.AllowNone: True,
                                                     },
                                                     "min_error": {
                                                         MK.Type: types.Number,
-                                                        MK.Required: False,
                                                         MK.AllowNone: True,
                                                     },
                                                 },
@@ -147,12 +143,10 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
                                                 MK.Content: {
                                                     "rel_error": {
                                                         MK.Type: types.Number,
-                                                        MK.Required: False,
                                                         MK.AllowNone: True,
                                                     },
                                                     "min_error": {
                                                         MK.Type: types.Number,
-                                                        MK.Required: False,
                                                         MK.AllowNone: True,
                                                     },
                                                 },


### PR DESCRIPTION
Solve deprecation warning: remove .Required in config parser

The Required option is going to be deprecated @olwijn, no need to specify this anymore. It will still work, but it leads to deprecation warnings when running FlowNet.

---

### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`.
- [ ] :books: I have considered updating the documentation.