### PR TITLE
Only print THPRES between neighboring equil regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - [#372](https://github.com/equinor/flownet/pull/372) Added option to let the additional flownodes initially be placed within the original volume rather than within the convex hull of the real wells. To do this set place_nodes_in_volume_reservoir to true.
 
 ### Fixes
+- [#403](https://github.com/equinor/flownet/pull/403) Fixes bug in generation of THPRES keyword for OPM Flow
 - [#391](https://github.com/equinor/flownet/pull/391) Fixes bug in generation of yaml files for visualization in Webviz.
 - [#372](https://github.com/equinor/flownet/pull/372) Fixes bug of hull_factor not actually being used for placing additional nodes outside the perforations.
 - [#374](https://github.com/equinor/flownet/pull/374) Fix for memory leak in result plotting script.

--- a/src/flownet/parameters/_equilibration.py
+++ b/src/flownet/parameters/_equilibration.py
@@ -113,7 +113,22 @@ class Equilibration(Parameter):
             for connections_at_node in self._network.connection_at_nodes:
                 eqlnum_combinations.extend(list(combinations(connections_at_node, 2)))
 
-            eqlnum_combinations = list(set(eqlnum_combinations))
+            # Go from tube index to equilibrium region index (0-index to 1-index)
+            # remove duplicates, and only one way thpres needed
+            eqlnum_combinations = list(
+                {
+                    (
+                        self._eqlnum.loc[tube_a, "EQLNUM"],
+                        self._eqlnum.loc[tube_b, "EQLNUM"],
+                    )
+                    for _, [tube_a, tube_b] in enumerate(eqlnum_combinations)
+                    if self._eqlnum.loc[tube_b, "EQLNUM"]
+                    > self._eqlnum.loc[tube_a, "EQLNUM"]
+                }
+            )
+            # sort for readability
+            eqlnum_combinations.sort()
+
             eqlnum1 = list(list(zip(*eqlnum_combinations))[0])
             eqlnum2 = list(list(zip(*eqlnum_combinations))[1])
 

--- a/src/flownet/templates/THPRES.jinja2
+++ b/src/flownet/templates/THPRES.jinja2
@@ -2,6 +2,6 @@
 -- FROM TO VALUE
 THPRES
 {% for i in range(eqlnum1|length) -%}
- {{ eqlnum1[i] + 1 }} {{ eqlnum2[i] + 1 }} 1* /
+ {{ eqlnum1[i]}} {{ eqlnum2[i]}} 1* /
 {% endfor -%}
 /


### PR DESCRIPTION
There is currently a bug in the code that prints threshold pressures between all flow tubes if there is more than one equilibrium region. Thus many threshold pressures are added within one equilibrium region as well (probably from when individual and global were the only available options). This PR makes it such that THPRES is only printed for neighboring equilibrium regions (sorted for readability).

---

### Contributor checklist

- [x] :tada: This PR closes #400.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [x] Add conversion from finding combination of tubes connected at nodes to find combination of regions connected at nodes
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have considered adding a new entry in `CHANGELOG.md`.
- [ ] :books: I have considered updating the documentation.