### PR TITLE
Rel error 409

### DIFF
--- a/src/flownet/config_parser/_config_parser.py
+++ b/src/flownet/config_parser/_config_parser.py
@@ -2281,11 +2281,8 @@ def parse_config(
     fld = []
     for idx in range(len(config.flownet.data_source.simulation.vectors)):
         obs = config.flownet.data_source.simulation.vectors[idx]
-        if (
-            (obs.min_error is not None
-            and obs.rel_error is None)
-            or (obs.min_error is None
-            and obs.rel_error is not None)
+        if (obs.min_error is not None and obs.rel_error is None) or (
+            obs.min_error is None and obs.rel_error is not None
         ):
             fld.append(config.flownet.data_source.simulation.vectors._fields[idx])
 

--- a/src/flownet/config_parser/_config_parser.py
+++ b/src/flownet/config_parser/_config_parser.py
@@ -1,4 +1,3 @@
-#%%
 import warnings
 import os
 import pathlib
@@ -2279,19 +2278,19 @@ def parse_config(
             "method can only be used when a simulation model is supplied as datasource."
         )
 
-    idx_list = []
+
+    fld=[]
     for idx in range(len(config.flownet.data_source.simulation.vectors)):
         obs = config.flownet.data_source.simulation.vectors[idx]
-        #if not ( isinstance(obs.min_error, (int, float)) and isinstance(obs.rel_error, (int, float))
-        #    or (obs.min_error is None and obs.rel_error is None) ):
-        if ( not (obs.min_error is not None and obs.rel_error is not None) ):
-            idx_list.append(idx)
+        if (obs.min_error is not None and obs.rel_error is None or
+           obs.min_error is None and obs.rel_error is not None):
+            fld.append(config.flownet.data_source.simulation.vectors._fields[idx])
 
-    for i in idx_list:
+    if fld:
         raise ValueError(
             f"Both min_error and rel_error must be set. "
             f"This requirement is not satisfied for "
-            f"'{config.flownet.data_source.simulation.vectors._fields[i]}' observations"
+            f" {fld}  observations"
         )
 
     return config

--- a/src/flownet/config_parser/_config_parser.py
+++ b/src/flownet/config_parser/_config_parser.py
@@ -2,7 +2,7 @@ import warnings
 import os
 import pathlib
 from typing import Dict, Optional, List
- 
+
 import numpy as np
 import yaml
 from configsuite import transformation_msg, types, MetaKeys as MK, ConfigSuite
@@ -2278,12 +2278,15 @@ def parse_config(
             "method can only be used when a simulation model is supplied as datasource."
         )
 
-
-    fld=[]
+    fld = []
     for idx in range(len(config.flownet.data_source.simulation.vectors)):
         obs = config.flownet.data_source.simulation.vectors[idx]
-        if (obs.min_error is not None and obs.rel_error is None or
-           obs.min_error is None and obs.rel_error is not None):
+        if (
+            (obs.min_error is not None
+            and obs.rel_error is None)
+            or (obs.min_error is None
+            and obs.rel_error is not None)
+        ):
             fld.append(config.flownet.data_source.simulation.vectors._fields[idx])
 
     if fld:

--- a/src/flownet/config_parser/_config_parser.py
+++ b/src/flownet/config_parser/_config_parser.py
@@ -1,8 +1,9 @@
+#%%
 import warnings
 import os
 import pathlib
 from typing import Dict, Optional, List
-
+ 
 import numpy as np
 import yaml
 from configsuite import transformation_msg, types, MetaKeys as MK, ConfigSuite
@@ -2276,6 +2277,21 @@ def parse_config(
         raise ValueError(
             f"'The {config.flownet.prior_volume_distribution}' volume distribution "
             "method can only be used when a simulation model is supplied as datasource."
+        )
+
+    idx_list = []
+    for idx in range(len(config.flownet.data_source.simulation.vectors)):
+        obs = config.flownet.data_source.simulation.vectors[idx]
+        #if not ( isinstance(obs.min_error, (int, float)) and isinstance(obs.rel_error, (int, float))
+        #    or (obs.min_error is None and obs.rel_error is None) ):
+        if ( not (obs.min_error is not None and obs.rel_error is not None) ):
+            idx_list.append(idx)
+
+    for i in idx_list:
+        raise ValueError(
+            f"Both min_error and rel_error must be set. "
+            f"This requirement is not satisfied for "
+            f"'{config.flownet.data_source.simulation.vectors._fields[i]}' observations"
         )
 
     return config


### PR DESCRIPTION
With this PR, in case for an observation either rel_error or min_error is missing an error message is given:
e.g:
 data_source:
    simulation:
      input_case: ../input_model/egg/EGG_MODEL_ECL
      vectors:
        WBHP:
         rel_error: 0.005
        WOPR:
          min_error: 1

gives the error:

_ValueError: Both min_error and rel_error must be set. This requirement is not satisfied for  ['WBHP', 'WOPR']  observations_

In case both rel_error and min_error are absent flownet gives an error as the configuration file  does not satisfy the template requirements as defined  in _config_parser.py  (using the **configsuite** module). The error message is however not very insightful:
_ValueError: The configuration is not valid:Is x a dictionary is false on input 'None'._ 
To fix this would require to dig into the  **configsuite** module which I park for now as it may have not a high priority.
The most important aspect of this PR is that observations are not silently  skipped anymore in case of incomplete input specification.




---

### Contributor checklist

- [ ] :tada: This PR closes #409
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`.
- [ ] :books: I have considered updating the documentation.