### PR TITLE
Fix build by updating code to reflect new pylint warning/hints

### DIFF
--- a/src/flownet/ahm/_assisted_history_matching.py
+++ b/src/flownet/ahm/_assisted_history_matching.py
@@ -88,7 +88,7 @@ class AssistedHistoryMatching:
             Nothing
 
         """
-        with open(self.output_folder / "webviz_config.yml", "w") as fh:
+        with open(self.output_folder / "webviz_config.yml", "w", encoding="utf8") as fh:
             fh.write(
                 _TEMPLATE_ENVIRONMENT.get_template(
                     "webviz_ahm_config.yml.jinja2"

--- a/src/flownet/ahm/_run_ahm.py
+++ b/src/flownet/ahm/_run_ahm.py
@@ -852,7 +852,7 @@ def run_flownet_history_matching(
 
     regional_parameters = [
         param
-        for param in {"bulkvolume_mult", "porosity", "permeability"}
+        for param in ["bulkvolume_mult", "porosity", "permeability"]
         if getattr(config.model_parameters, param + "_regional_scheme") != "individual"
     ]
     (ci2ri, regional_porv_poro_trans_dist_values,) = _get_regional_distribution(

--- a/src/flownet/config_parser/_config_parser_hyperparam.py
+++ b/src/flownet/config_parser/_config_parser_hyperparam.py
@@ -104,7 +104,7 @@ def parse_hyperparam_config(base_config: pathlib.Path) -> list:
         List of hyperparameters.
 
     """
-    with open(base_config) as file:
+    with open(base_config, encoding="utf8") as file:
         hyper_config = yaml.load(file, Loader=yaml.FullLoader)
 
     return list_hyperparameters(hyper_config, hyperparameters=[])

--- a/src/flownet/ert/_create_ert_setup.py
+++ b/src/flownet/ert/_create_ert_setup.py
@@ -106,7 +106,7 @@ def create_observation_file(
         template = _TEMPLATE_ENVIRONMENT.get_template(
             f"observations.{obs_export_type}.jinja2"
         )
-        with open(export_filename, "w") as fh:
+        with open(export_filename, "w", encoding="utf8") as fh:
             fh.write(
                 template.render(
                     {
@@ -136,7 +136,7 @@ def _create_ert_parameter_file(
         Nothing
 
     """
-    with open(output_folder / "parameters.ertparam", "w") as fh:
+    with open(output_folder / "parameters.ertparam", "w", encoding="utf8") as fh:
         index = 0  # Prepend index in parameter name to enforce uniqueness in ERT
         for parameter in parameters:
             for random_variable in parameter.random_variables:
@@ -146,7 +146,7 @@ def _create_ert_parameter_file(
 
     # This is an ERT workaround. ERT parameter configuration needs a template file
     # which we don't use. Call the template file "EMPTYFILE" and let be it empty.
-    with open(output_folder / "EMPTYFILE", "a") as fh:
+    with open(output_folder / "EMPTYFILE", "a", encoding="utf8") as fh:
         fh.close()
 
 
@@ -230,7 +230,7 @@ def create_ert_setup(  # pylint: disable=too-many-arguments
             }
         )
 
-    with open(ert_config_file, "w") as fh:
+    with open(ert_config_file, "w", encoding="utf8") as fh:
         fh.write(template.render(configuration))
 
     shutil.copyfile(
@@ -270,7 +270,9 @@ def create_ert_setup(  # pylint: disable=too-many-arguments
     if hasattr(config.ert, "analysis"):
         for i, analysis_item in enumerate(config.ert.analysis):
             with open(
-                output_folder / f"SAVE_ITERATION_ANALYTICS_WORKFLOW_{i}", "w"
+                output_folder / f"SAVE_ITERATION_ANALYTICS_WORKFLOW_{i}",
+                "w",
+                encoding="utf8",
             ) as fh:
                 fh.write(
                     analytics_workflow_template.render(
@@ -293,7 +295,9 @@ def create_ert_setup(  # pylint: disable=too-many-arguments
                 )
 
     shutil.copyfile(args.config, output_folder / args.config.name)
-    with open(os.path.join(output_folder, "pipfreeze.output"), "w") as fh:
+    with open(
+        os.path.join(output_folder, "pipfreeze.output"), "w", encoding="utf8"
+    ) as fh:
         subprocess.call(["pip", "freeze"], stdout=fh)
 
     for section in ["RUNSPEC", "PROPS", "SOLUTION", "SCHEDULE"]:

--- a/src/flownet/ert/forward_models/_render_realization.py
+++ b/src/flownet/ert/forward_models/_render_realization.py
@@ -30,7 +30,7 @@ def _ert_samples2simulation_input(
 
     """
     if random_samples.suffix == ".json":
-        with open(random_samples, "r") as json_file:
+        with open(random_samples, "r", encoding="utf8") as json_file:
             unsorted_random_samples = json.load(json_file)["FLOWNET_PARAMETERS"]
     elif random_samples.suffix == ".parquet":
         df = pd.read_parquet(random_samples)

--- a/src/flownet/parameters/_relative_permeability.py
+++ b/src/flownet/parameters/_relative_permeability.py
@@ -122,7 +122,7 @@ def interpolate_wo(parameter: float, scalrec: Dict) -> Dict:
     parameter = abs(parameter)
 
     parameter_dict = {}
-    for elem in {"swirr", "swl", "swcr", "sorw", "nw", "now", "krwend", "kroend"}:
+    for elem in ["swirr", "swl", "swcr", "sorw", "nw", "now", "krwend", "kroend"]:
         parameter_dict[elem] = (
             scalrec[elem][i] * (1 - parameter) + scalrec[elem][j] * parameter
         )
@@ -153,7 +153,7 @@ def interpolate_go(parameter: float, scalrec: Dict) -> Dict:
     parameter = abs(parameter)
 
     parameter_dict = {}
-    for elem in {"swirr", "swl", "sgcr", "sorg", "ng", "nog", "krgend", "kroend"}:
+    for elem in ["swirr", "swl", "sgcr", "sorg", "ng", "nog", "krgend", "kroend"]:
         parameter_dict[elem] = (
             scalrec[elem][i] * (1 - parameter) + scalrec[elem][j] * parameter
         )

--- a/src/flownet/prediction/_run_pred.py
+++ b/src/flownet/prediction/_run_pred.py
@@ -45,7 +45,7 @@ def run_flownet_prediction(config, args):
         args.output_folder / "parameters.parquet",
     )
 
-    with open(args.output_folder / "webviz_config.yml", "w") as fh:
+    with open(args.output_folder / "webviz_config.yml", "w", encoding="utf8") as fh:
         fh.write(
             _TEMPLATE_ENVIRONMENT.get_template("webviz_pred_config.yml.jinja2").render(
                 {"runpath": config.ert.runpath}

--- a/src/flownet/realization/_simulation_realization.py
+++ b/src/flownet/realization/_simulation_realization.py
@@ -114,7 +114,9 @@ class SimulationRealization:
             # Render SCHEDULE include file
             template = template_environment.get_template("HISTORY_SCHEDULE.inc.jinja2")
             with open(
-                output_folder_path / "include" / "HISTORY_SCHEDULE.inc", "w"
+                output_folder_path / "include" / "HISTORY_SCHEDULE.inc",
+                "w",
+                encoding="utf8",
             ) as fh:
                 fh.write(
                     template.render(
@@ -124,7 +126,9 @@ class SimulationRealization:
 
         for section in self._includes:
             with open(
-                output_folder_path / "include" / f"{section}_PARAMETERS.inc", "w"
+                output_folder_path / "include" / f"{section}_PARAMETERS.inc",
+                "w",
+                encoding="utf8",
             ) as fh:
                 fh.write(self._includes[section])
 
@@ -143,7 +147,9 @@ class SimulationRealization:
 
         # Render main Flow .DATA file
         template = template_environment.get_template("TEMPLATE_MODEL.DATA.jinja2")
-        with open(output_folder_path / "FLOWNET_REALIZATION.DATA", "w") as fh:
+        with open(
+            output_folder_path / "FLOWNET_REALIZATION.DATA", "w", encoding="utf8"
+        ) as fh:
             fh.write(template.render(configuration))
 
         # Copy static files

--- a/src/flownet/utils/observations.py
+++ b/src/flownet/utils/observations.py
@@ -16,7 +16,7 @@ def _read_ert_obs(ert_obs_file_name: pathlib.Path) -> dict:
     assert os.path.exists(ert_obs_file_name) == 1
     ert_obs: dict = {}
     text = ""
-    with open(ert_obs_file_name, "r") as a_ert_file:
+    with open(ert_obs_file_name, "r", encoding="utf8") as a_ert_file:
         for line in a_ert_file:
             text = text + line
 
@@ -49,5 +49,5 @@ def _read_yaml_obs(yaml_obs_file_name: pathlib.Path) -> dict:
         dictionary that contains the information in a YAML observation file
     """
     assert os.path.exists(yaml_obs_file_name) == 1
-    with open(yaml_obs_file_name, "r") as a_yaml_file:
+    with open(yaml_obs_file_name, "r", encoding="utf8") as a_yaml_file:
         return yaml.load(a_yaml_file, Loader=yaml.FullLoader)


### PR DESCRIPTION
This PR fixes the failed build by addressing warnings/hints from the latest version of pylint.
  * `open()` is now used with `encoding="utf8"` (to avoid errors from one OS to another)
  * Iteration over some hard-coded sequences is changed from using sets to lists (faster)