### PR TITLE
Layer-based assignment of prior flownet cell volumes

### DIFF
--- a/src/flownet/ahm/_run_ahm.py
+++ b/src/flownet/ahm/_run_ahm.py
@@ -584,6 +584,7 @@ def run_flownet_history_matching(
         area=area,
         fault_planes=df_fault_planes,
         fault_tolerance=config.flownet.fault_tolerance,
+        volume_layering=config.flownet.prior_volume_layering,
     )
 
     if config.flownet.prior_volume_distribution == "voronoi_per_tube":

--- a/src/flownet/config_parser/_config_parser.py
+++ b/src/flownet/config_parser/_config_parser.py
@@ -531,6 +531,15 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
                         "    factor of the FlowNet model generation process or by setting the "
                         "    place_nodes_in_volume_reservoir to true.",
                     },
+                    "prior_volume_layering": {
+                        MK.Type: types.List,
+                        MK.Content: {
+                            MK.Item: {
+                                MK.Type: types.Number,
+                                MK.AllowNone: True,
+                            }
+                        },
+                    },
                     "hyperopt": {
                         MK.Type: types.NamedDict,
                         MK.Content: {

--- a/src/flownet/data/from_flow.py
+++ b/src/flownet/data/from_flow.py
@@ -435,7 +435,7 @@ class FlowData(FromSource):
         cell_volumes = np.zeros(len(properties_per_cell["model"].values))
 
         # depths should be a list of depths provided by the user. it may also be empty
-        depths = [2570]
+        depths = network._volume_layering
 
         # Add 0 depth level and arrange from deep to shallow)
         depths.append(0)

--- a/src/flownet/data/from_flow.py
+++ b/src/flownet/data/from_flow.py
@@ -417,40 +417,74 @@ class FlowData(FromSource):
             for cell in self._grid.cells(active=True)
         ]
 
-        # Determine nearest flow tube cell for each cell in the original model
-        tree = KDTree(flownet_cell_midpoints)
-        _, matched_indices = tree.query(model_cell_mid_points, k=[1])
-
-        # Distribute the original model's volume per cell to flownet tubes cells that are nearest.
-        tube_cell_volumes = np.zeros(len(flownet_cell_midpoints))
-
-        for cell_i, tube_cell_id in enumerate(matched_indices):
-            tube_cell_volumes[tube_cell_id[0]] += model_cell_volume[cell_i]
-
         # Get a mapping from tube cells to tubes
         properties_per_cell = pd.DataFrame(
             pd.DataFrame(data=network.grid.index, index=network.grid.model).index
         )
 
-        # Sum all tube cell volumes in a tube
-        properties_per_cell["distributed_volume"] = tube_cell_volumes
-        tube_volumes = properties_per_cell.groupby(by="model").sum().values
-
         # Get the active cells per tube
-        active_cells_per_tube = (
-            properties_per_cell.reset_index().groupby(["model"]).size() - 1
-        )
+        #active_cells_per_tube = (
+        #        properties_per_cell.reset_index().groupby(["model"]).size() - 1
+        #)
 
         # Distribute tube volume over the active cells of the flownet.
-        # The last cell of each each tube is inactive and thefore gets 0 volume assigned.
+        # The last cell of each each tube is inactive and therefore gets 0 volume assigned.
         # Evenly distribute the volume over cells of the tube
+        #cell_volumes = np.zeros(len(properties_per_cell["model"].values))
+        #for i, tube in enumerate(properties_per_cell["model"].values[:-1]):
+        #    if (
+        #            properties_per_cell["model"].values[i]
+        #            == properties_per_cell["model"].values[i + 1]
+        #    ):
+        #        cell_volumes[i] = tube_volumes[tube] / active_cells_per_tube[tube]
+
+        # START NEW CODE - Get a mapping from tube cells to tubes
+        properties_per_cell = pd.DataFrame(
+            pd.DataFrame(data=network.grid.index, index=network.grid.model).index
+        )
         cell_volumes = np.zeros(len(properties_per_cell["model"].values))
-        for i, tube in enumerate(properties_per_cell["model"].values[:-1]):
-            if (
-                properties_per_cell["model"].values[i]
-                == properties_per_cell["model"].values[i + 1]
-            ):
-                cell_volumes[i] = tube_volumes[tube] / active_cells_per_tube[tube]
+
+        # depths should be a list of depths provided by the user. it may also be empty
+        depths = [2570]
+
+        # Add 0 depth level and arrange from deep to shallow)
+        depths.append(0)
+        depths.sort(reverse=True)
+
+        # Perform mapping of volumes between two depth levels
+        for ic in range(len(depths)):
+            if ic == 0:
+                # Add a very deep dummy level
+                dr = [1.e10, depths[ic]]
+            else:
+                dr = [depths[ic-1], depths[ic]]
+
+            tube_cell_volumes = np.zeros(len(flownet_cell_midpoints))
+
+            # Identify cells located between the current lower and upper depths levels
+            flownet_indices = [idx for idx, val in enumerate(network.cell_midpoints[2]) if (dr[0] >= val > dr[1])]
+            model_indices = [idx for idx, val in enumerate(model_cell_mid_points[:, 2]) if (dr[0] >= val > dr[1])]
+
+            # Determine nearest flow tube cell for each cell in the original model
+            tree = KDTree(flownet_cell_midpoints[flownet_indices, :])
+            _, matched_indices = tree.query(model_cell_mid_points[model_indices], k=[1])
+
+            # Assign each reservoir model volume to a flow tube
+            for cell_i, tube_cell_id in enumerate(matched_indices):
+                tube_cell_volumes[flownet_indices[tube_cell_id[0]]] += model_cell_volume[model_indices[cell_i]]
+
+            # Compute the total volumes per tube section between the current depth levels
+            properties_per_cell["distributed_volume"] = tube_cell_volumes
+            tube_volumes = properties_per_cell.groupby(by="model").sum().values
+
+            # Evenly distribute tube volumes over the tube cells between the current depth levels
+            for tube in range(len(tube_volumes)):
+                indices = [i for i, x in enumerate(network.grid.model.iloc[flownet_indices].values.tolist()) if
+                           x == tube]
+                #  to do: remove indices corresponding to the last (inactive) cell in a flow tube
+
+                for i in range(len(indices)):
+                    cell_volumes[flownet_indices[indices[i]]] += tube_volumes[tube] / len(indices)
 
         return cell_volumes
 

--- a/src/flownet/network_model/_network_model.py
+++ b/src/flownet/network_model/_network_model.py
@@ -20,6 +20,7 @@ class NetworkModel:
         area: float,
         fault_planes: Optional[pd.DataFrame] = None,
         fault_tolerance: float = 1.0e-5,
+        volume_layering: List = [],
     ):
         """
         Creates a network of one dimensional models.
@@ -51,6 +52,7 @@ class NetworkModel:
         self._nncs: List[Tuple[int, int]] = self._calculate_nncs()
 
         self._initial_cell_volumes = np.ones((len(self.connection_midpoints), 1))
+        self._volume_layering = list(volume_layering)
 
         self._fault_planes: Optional[pd.DataFrame] = None
         self._faults: Optional[Dict] = None


### PR DESCRIPTION
*Insert a description of your pull request (PR) here, and check off the boxes below when they are done.*

This is a draft PR that aims to provide the option to map reservoir volumes to Flownet cells, based on a list of depth levels. Reservoir volumes should not be mapped across these depths. This could be used for example to prevent the transfer of large volumes below an oil-water contact to FlowNet cells above the contact, leading to an overestimation of the FOIP after equilibration.

---

### Contributor checklist

- [X] :tada: This PR closes #416.
- [X] :scroll: I have broken down my PR into the following tasks:
   - [X] Task 1 - Map Eclipse volumes to Flownet volumes between specified depth levels
   - [X] Task 2 - Provide the user option to specify multiple depth levels
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`.
- [ ] :books: I have considered updating the documentation.