### PR TITLE
Adds ERT workflow to export FlowNet predictions to CSV file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
             "flownet_run_flow=flownet.ert.forward_models:run_flow",
             "flownet_save_iteration_parameters=flownet.ert.forward_models:save_iteration_parameters",
             "flownet_save_iteration_analytics=flownet.ert.forward_models:save_iteration_analytics",
+            "flownet_save_predictions=flownet.ert.forward_models:save_predictions",
             "flownet_plot_results=flownet.utils.plot_results:main",
         ],
     },

--- a/src/flownet/config_parser/_config_parser_pred.py
+++ b/src/flownet/config_parser/_config_parser_pred.py
@@ -158,6 +158,32 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
                     },
                 },
             },
+            "export": {
+                MK.Type: types.NamedDict,
+                MK.Content: {
+                    "csv_outfile": {
+                        MK.Type: types.String,
+                        MK.AllowNone: True,
+                        MK.Description: "Name of CSV file containing the prediction output of the FlowNet ensemble. ",
+                    },
+                    "quantity": {
+                        MK.Type: types.List,
+                        MK.Content: {
+                            MK.Item: {
+                                MK.Type: types.String,
+                                MK.AllowNone: True,
+                            }
+                        },
+                        MK.Transformation: _to_upper,
+                        MK.Description: "List of summary vectors to be exported. ",
+                    },
+                    "end_date": {
+                        MK.Type: types.Date,
+                        MK.AllowNone: True,
+                        MK.Description: "End date in YYYY-MM-DD format.",
+                    },
+                },
+            },
         },
     }
 

--- a/src/flownet/ert/forward_models/__init__.py
+++ b/src/flownet/ert/forward_models/__init__.py
@@ -2,4 +2,5 @@ from ._save_iteration_parameters import save_iteration_parameters
 from ._delete_simulation_output import delete_simulation_output
 from ._flow_job import run_flow
 from ._iteration_analytics import save_iteration_analytics
+from ._save_predictions import save_predictions
 from ._render_realization import render_realization

--- a/src/flownet/ert/forward_models/_save_predictions.py
+++ b/src/flownet/ert/forward_models/_save_predictions.py
@@ -1,0 +1,164 @@
+import argparse
+from datetime import datetime
+from multiprocessing.pool import ThreadPool
+import functools
+import glob
+import pathlib
+from typing import Any, Dict, Optional, List, Tuple
+
+import pandas as pd
+from ecl.summary import EclSum
+
+from flownet.ert.forward_models.utils import get_last_iteration
+
+
+def _load_simulations(runpath: str, ecl_base: str) -> Tuple[str, Optional[EclSum]]:
+    """
+    Internal helper function to load simulation results in parallel.
+
+    Args:
+        runpath: Path to where the realization is run.
+        ecl_base: Path to where the realization is run.
+
+    Returns:
+        (runpath, EclSum), or (runpath, None) in case of failed simulation (inexistent .UNSMRY file)
+
+    """
+    try:
+        eclsum = EclSum(str(pathlib.Path(runpath) / pathlib.Path(ecl_base)))
+    except KeyboardInterrupt:
+        raise
+    except Exception:  # pylint: disable=broad-except
+        eclsum = None
+    except BaseException:  # pylint: disable=broad-except
+        pass
+
+    return runpath, eclsum
+
+
+def make_dataframe_simulation_data(
+    mode: str, path: str, eclbase_file: str, keys: List[str], end_date: datetime
+) -> Tuple[pd.DataFrame, str, int]:
+    """
+    Internal helper function to generate dataframe containing
+    data from ensemble of simulations from selected simulation keys
+
+    Args:
+        mode: String with mode in which flownet is run: prediction (pred) or assisted history matching (ahm)
+        path: path to folder containing ensemble of simulations
+        eclbase_file: name of simulation case file
+        keys: list of prefix of quantities of interest to be loaded
+        end_date: end date of time period for accuracy analysis
+
+    Raises:
+        ValueError: If mode is invalid (not pred or ahm).
+
+    Returns:
+        df_sim: Pandas dataframe contained data from ensemble of simulations
+        iteration: current AHM iteration number
+        nb_real: number of realizations
+
+    """
+    if mode == "pred":
+        runpath_list = glob.glob(path)
+        iteration = "latest"
+    elif mode == "ahm":
+        (i, runpath_list) = get_last_iteration(path)
+        iteration = str(i)
+    else:
+        raise ValueError(
+            f"{mode} is not a valid mode to run flownet with. Choose ahm or pred."
+        )
+
+    partial_load_simulations = functools.partial(
+        _load_simulations, ecl_base=eclbase_file
+    )
+
+    # Load summary files of latest iteration
+    realizations_dict: Dict[str, Any] = {}
+    realizations_dict = dict(
+        ThreadPool(processes=None).map(partial_load_simulations, runpath_list)
+    )
+
+    n_realization = 0
+
+    # Load all simulation results for the required vector keys
+    df_sim = pd.DataFrame()
+    for _, eclsum in realizations_dict.items():
+        if eclsum and eclsum.dates[-1] >= end_date:
+            df_realization = eclsum.pandas_frame(
+                column_keys=[key + "*" for key in keys]
+            )
+            df_realization["DATE"] = eclsum.dates
+            df_realization["REALIZATION"] = n_realization
+
+            df_sim = df_sim.append(df_realization)
+            n_realization += 1
+
+    return df_sim, iteration, n_realization
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(prog=("Save ensemble predictions to CSV file."))
+    parser.add_argument("mode", type=str, help="Mode: ahm or pred")
+    parser.add_argument("runpath", type=str, help="Path to the ERT runpath.")
+    parser.add_argument(
+        "eclbase", type=str, help="Path to the simulation from runpath."
+    )
+    parser.add_argument(
+        "end",
+        type=lambda s: datetime.strptime(s, "%Y-%m-%d"),
+        help="End date (YYYY-MM-DD) of prediction simulation.",
+    )
+    parser.add_argument(
+        "quantity",
+        type=str,
+        help="List of names of quantities of interest for exporting predictions.",
+    )
+    parser.add_argument(
+        "outfile",
+        type=str,
+        help="Prefix of name of CSV file containing the prediction output of the FlowNet ensemble.",
+    )
+    args = parser.parse_args()
+    args.runpath = args.runpath.replace("%d", "*")
+
+    return args
+
+
+def save_predictions():
+    """
+    This function is called as a post-simulation workflow in ERT, exporting predictions
+    of the FlowNet ensemble of all iterations to a CSV file in the FlowNet output folder.
+
+    Args:
+        None
+
+    Returns:
+        Nothing
+
+    """
+    args = parse_arguments()
+
+    print("Saving predictions...", end=" ", flush=True)
+
+    # Vector keys to export
+    vector_keys = list(args.quantity.replace("[", "").replace("]", "").split(","))
+
+    # Load ensemble of FlowNet
+    (df_sim, iteration, nb_real) = make_dataframe_simulation_data(
+        args.mode,
+        args.runpath,
+        args.eclbase,
+        vector_keys,
+        args.end,
+    )
+
+    # Saving dataframe to CSV file
+    df_sim.to_csv(args.outfile + "_iter-" + str(iteration) + ".csv", index=False)
+
+    print("[Done]")
+
+
+if __name__ == "__main__":
+    save_predictions()

--- a/src/flownet/static/SAVE_PREDICTIONS_WORKFLOW_JOB
+++ b/src/flownet/static/SAVE_PREDICTIONS_WORKFLOW_JOB
@@ -1,0 +1,10 @@
+INTERNAL      FALSE
+EXECUTABLE    flownet_save_predictions
+MIN_ARG       6
+MAX_ARG       6
+ARG_TYPE      0 STRING
+ARG_TYPE      1 STRING
+ARG_TYPE      2 STRING
+ARG_TYPE      3 STRING
+ARG_TYPE      4 STRING
+ARG_TYPE      5 STRING

--- a/src/flownet/templates/SAVE_PREDICTIONS_WORKFLOW.jinja2
+++ b/src/flownet/templates/SAVE_PREDICTIONS_WORKFLOW.jinja2
@@ -1,0 +1,1 @@
+SAVE_PREDICTIONS_WORKFLOW_JOB {{ mode }} {{ run_path }} {{ ecl_base }} {{ prediction_end }} {{ export_quantity }} {{ export_outfile }}

--- a/src/flownet/templates/pred_config.ert.jinja2
+++ b/src/flownet/templates/pred_config.ert.jinja2
@@ -1,3 +1,19 @@
 DEFINE <RANDOM_SAMPLES> <CONFIG_PATH>/parameters.parquet
 
 {% include "./common_config.ert.jinja2" %}
+
+{%- if config.ert.analysis: %}
+LOAD_WORKFLOW_JOB ./SAVE_ITERATION_ANALYTICS_WORKFLOW_JOB
+
+{% for item in config.ert.analysis %}
+LOAD_WORKFLOW SAVE_ITERATION_ANALYTICS_WORKFLOW_{{ loop.index - 1 }}
+HOOK_WORKFLOW SAVE_ITERATION_ANALYTICS_WORKFLOW_{{ loop.index - 1 }} POST_SIMULATION
+{% endfor %}
+{%- endif %}
+
+{%- if config.export: %}
+LOAD_WORKFLOW_JOB ./SAVE_PREDICTIONS_WORKFLOW_JOB
+
+LOAD_WORKFLOW SAVE_PREDICTIONS_WORKFLOW
+HOOK_WORKFLOW SAVE_PREDICTIONS_WORKFLOW POST_SIMULATION
+{%- endif %}


### PR DESCRIPTION
*Adds ERT workflow to export FlowNet predictions to CSV file to be used in subsequent computational workflows for data-driven predictions (e.g. machine learning)*

---

### Contributor checklist

- [ ] :tada: This PR adds functionality to export FlowNet prediction results to a CSV file.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Add new options to the parser of prediction mode.
   - [ ] Create forward_model _save_predictions.
   - [ ] Add post-simulation workflow job to ERT setup.
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`.
- [ ] :books: I have considered updating the documentation.