### PR TITLE
Prevents unnecessary repeated search for well starting date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 
 ### Changes
-
+- [#440](https://github.com/equinor/flownet/pull/440) Speeds up workflow by removing search for well starting date from inside for-loop when processing historical production data in `_schedule.py`.
 
 ## [0.5.3] - 2021-09-23
 


### PR DESCRIPTION
*Prevents unnecessary repeated search for well starting date inside for-loop when processing historical schedule production data*

---

### Contributor checklist

- [x] :tada: This PR closes #439.
- [x] :scroll: I have broken down my PR into the following tasks:
   - [x] Removed search for well starting date from inside for-loop
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have considered adding a new entry in `CHANGELOG.md`.
- [x] :books: I have considered updating the documentation.