### PR TITLE
adaptations to allow for production temperature history matching

### DIFF
--- a/src/flownet/config_parser/_config_parser.py
+++ b/src/flownet/config_parser/_config_parser.py
@@ -2144,7 +2144,7 @@ def parse_config(
             f"'{config.flownet.inj_control_mode}' is not valid.\n"
             f"Valid options are {inj_control_modes}. "
         )
-
+    # pylint: disable=fixme
     # TODO: the phase keyword in config is now generalised and the term phase is not so appropriate anymore
     for phase in config.flownet.phases:
         if phase not in ["oil", "gas", "water", "disgas", "vapoil", "brine", "temp"]:

--- a/src/flownet/config_parser/_config_parser.py
+++ b/src/flownet/config_parser/_config_parser.py
@@ -2145,11 +2145,12 @@ def parse_config(
             f"Valid options are {inj_control_modes}. "
         )
 
+    #TODO: the phase keyword in config is now generalised and the term phase is not so appropriate anymore
     for phase in config.flownet.phases:
-        if phase not in ["oil", "gas", "water", "disgas", "vapoil"]:
+        if phase not in ["oil", "gas", "water", "disgas", "vapoil", 'brine', 'temp']:
             raise ValueError(
                 f"The {phase} phase is not a valid phase\n"
-                f"The valid phases are 'oil', 'gas', 'water', 'disgas' and 'vapoil'"
+                f"The valid phases are 'oil', 'gas', 'water', 'disgas', 'vapoil', 'brine' and 'temp'"
             )
     if (
         not {"vapoil", "disgas"}.isdisjoint(config.flownet.phases)

--- a/src/flownet/config_parser/_config_parser.py
+++ b/src/flownet/config_parser/_config_parser.py
@@ -2145,9 +2145,9 @@ def parse_config(
             f"Valid options are {inj_control_modes}. "
         )
 
-    #TODO: the phase keyword in config is now generalised and the term phase is not so appropriate anymore
+    # TODO: the phase keyword in config is now generalised and the term phase is not so appropriate anymore
     for phase in config.flownet.phases:
-        if phase not in ["oil", "gas", "water", "disgas", "vapoil", 'brine', 'temp']:
+        if phase not in ["oil", "gas", "water", "disgas", "vapoil", "brine", "temp"]:
             raise ValueError(
                 f"The {phase} phase is not a valid phase\n"
                 f"The valid phases are 'oil', 'gas', 'water', 'disgas', 'vapoil', 'brine' and 'temp'"

--- a/src/flownet/config_parser/_config_parser.py
+++ b/src/flownet/config_parser/_config_parser.py
@@ -320,6 +320,19 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
                                             },
                                         },
                                     },
+                                    "WTPCHEA": {
+                                        MK.Type: types.NamedDict,
+                                        MK.Content: {
+                                            "rel_error": {
+                                                MK.Type: types.Number,
+                                                MK.AllowNone: True,
+                                            },
+                                            "min_error": {
+                                                MK.Type: types.Number,
+                                                MK.AllowNone: True,
+                                            },
+                                        },
+                                    },
                                 },
                             },
                             "resampling": {

--- a/src/flownet/data/from_flow.py
+++ b/src/flownet/data/from_flow.py
@@ -173,6 +173,7 @@ class FlowData(FromSource):
                 - WSIR          Well Salt Injection Rate
                 - WSPT          Well Cumulative Salt Production
                 - WSIT          Well Cumulative Salt Injection
+                - WTICHEA       Well Injection Temperature
                 - WTPCHEA       Well Production Temperature
                 - WSTAT         Well status (OPEN, SHUT, STOP)
                 - TYPE          Well Type: "OP", "GP", "WI", "GI"
@@ -201,6 +202,7 @@ class FlowData(FromSource):
             "WSPT",
             "WSIT",
             "WTPCHEA",
+            "WTICHEA",
             "WSTAT",
         ]
 
@@ -250,8 +252,7 @@ class FlowData(FromSource):
             )
             wstat_default = "OPEN"
         else:
-            wstat_default = "OPEN" # hack
-            #wstat_default = "STOP" 
+            wstat_default = "STOP"
 
         df_production_data["WSTAT"] = df_production_data["WSTAT"].map(
             {

--- a/src/flownet/data/from_flow.py
+++ b/src/flownet/data/from_flow.py
@@ -173,6 +173,7 @@ class FlowData(FromSource):
                 - WSIR          Well Salt Injection Rate
                 - WSPT          Well Cumulative Salt Production
                 - WSIT          Well Cumulative Salt Injection
+                - WTPCHEA       Well Production Temperature
                 - WSTAT         Well status (OPEN, SHUT, STOP)
                 - TYPE          Well Type: "OP", "GP", "WI", "GI"
                 - PHASE         Main producing/injecting phase fluid: "OIL", "GAS", "WATER"
@@ -199,6 +200,7 @@ class FlowData(FromSource):
             "WSIR",
             "WSPT",
             "WSIT",
+            "WTPCHEA",
             "WSTAT",
         ]
 
@@ -248,7 +250,8 @@ class FlowData(FromSource):
             )
             wstat_default = "OPEN"
         else:
-            wstat_default = "STOP"
+            wstat_default = "OPEN" # hack
+            #wstat_default = "STOP" 
 
         df_production_data["WSTAT"] = df_production_data["WSTAT"].map(
             {

--- a/src/flownet/ert/forward_models/_flow_job.py
+++ b/src/flownet/ert/forward_models/_flow_job.py
@@ -30,6 +30,7 @@ def run_flow():
     flow_path = shutil.which("flow")
     if "FLOW_PATH" in os.environ:
         flow_path = os.environ.get("FLOW_PATH")
+        print(flow_path)
         if not os.path.isfile(flow_path):
             raise FileNotFoundError(
                 r"$FLOW_PATH does not point at a file that exists.\n \

--- a/src/flownet/realization/_schedule.py
+++ b/src/flownet/realization/_schedule.py
@@ -81,7 +81,7 @@ class Schedule:
                     WTEMP(
                         date=value["date"],
                         well_name=value["WELL_NAME"],
-                        temperature=value["WTPCHEA"],
+                        temperature=value["WTICHEA"],
                     )
                 )
 
@@ -254,8 +254,6 @@ class Schedule:
                         oil_total=value["WOPT"],
                         water_total=value["WWPT"],
                         gas_total=value["WGPT"],
-                        #salt_rate=value["WSPR"],
-                        #salt_total=value["WSPT"],
                         bhp=value["WBHP"],
                         thp=value["WTHP"],
                     )
@@ -276,8 +274,6 @@ class Schedule:
         """
         for _, value in self._df_production_data.iterrows():
             start_date = self._start_dates[value["WELL_NAME"]]
-            if value["WELL_NAME"] == "C-4H":
-                print(value["TYPE"])
             if value["TYPE"] == "WI" and start_date and value["date"] >= start_date:
                 self.append(
                     WCONINJH(
@@ -592,22 +588,22 @@ class Schedule:
 
         return vfp_tables
 
-    def has_brine(self) -> bool:
-        """Helper function to determine whether the schedule has brine data.
+    # def has_brine(self) -> bool:
+    #     """Helper function to determine whether the schedule has brine data.
 
-        Returns:
-            True if non zero brine data found, otherwise False
-        """
-        return (
-            sum(
-                [
-                    kw.salt_concentration
-                    for kw in self._schedule_items
-                    if kw.name == "WSALT"
-                ]
-            )
-            > 0
-        )
+    #     Returns:
+    #         True if non zero brine data found, otherwise False
+    #     """
+    #     return (
+    #         sum(
+    #             [
+    #                 kw.salt_concentration
+    #                 for kw in self._schedule_items
+    #                 if kw.name == "WSALT"
+    #             ]
+    #         )
+    #         > 0
+    #     )
 
     def get_nr_observations(self, training_set_fraction: float) -> int:
         """

--- a/src/flownet/realization/_schedule.py
+++ b/src/flownet/realization/_schedule.py
@@ -8,7 +8,15 @@ import numpy as np
 import pandas as pd
 
 from configsuite import ConfigSuite
-from ._simulation_keywords import Keyword, COMPDAT, WCONHIST, WCONINJH, WELSPECS, WSALT, WTEMP
+from ._simulation_keywords import (
+    Keyword,
+    COMPDAT,
+    WCONHIST,
+    WCONINJH,
+    WELSPECS,
+    WSALT,
+    WTEMP,
+)
 from ..network_model import NetworkModel
 
 
@@ -76,7 +84,7 @@ class Schedule:
 
         """
         for _, value in self._df_production_data.iterrows():
-            if value["WWIR"] > 0: #PJPE check
+            if value["WWIR"] > 0:  # PJPE check
                 self.append(
                     WTEMP(
                         date=value["date"],

--- a/src/flownet/realization/_schedule.py
+++ b/src/flownet/realization/_schedule.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 
 from configsuite import ConfigSuite
-from ._simulation_keywords import Keyword, COMPDAT, WCONHIST, WCONINJH, WELSPECS, WSALT
+from ._simulation_keywords import Keyword, COMPDAT, WCONHIST, WCONINJH, WELSPECS, WSALT, WTEMP
 from ..network_model import NetworkModel
 
 
@@ -64,7 +64,26 @@ class Schedule:
         self._calculate_wconhist()
         self._calculate_wconinjh()
         self._calculate_wsalt()
+        self._calculate_wtemp()
         print("done.", flush=True)
+
+    def _calculate_wtemp(self):
+        """
+        Helper Function that generates the WTEMP keywords based on temperature measurements.
+
+        Returns:
+            Nothing
+
+        """
+        for _, value in self._df_production_data.iterrows():
+            if value["WWIR"] > 0: #PJPE check
+                self.append(
+                    WTEMP(
+                        date=value["date"],
+                        well_name=value["WELL_NAME"],
+                        temperature=value["WTPCHEA"],
+                    )
+                )
 
     def _calculate_wsalt(self):
         """
@@ -235,8 +254,8 @@ class Schedule:
                         oil_total=value["WOPT"],
                         water_total=value["WWPT"],
                         gas_total=value["WGPT"],
-                        salt_rate=value["WSPR"],
-                        salt_total=value["WSPT"],
+                        #salt_rate=value["WSPR"],
+                        #salt_total=value["WSPT"],
                         bhp=value["WBHP"],
                         thp=value["WTHP"],
                     )
@@ -257,6 +276,8 @@ class Schedule:
         """
         for _, value in self._df_production_data.iterrows():
             start_date = self._start_dates[value["WELL_NAME"]]
+            if value["WELL_NAME"] == "C-4H":
+                print(value["TYPE"])
             if value["TYPE"] == "WI" and start_date and value["date"] >= start_date:
                 self.append(
                     WCONINJH(

--- a/src/flownet/realization/_simulation_keywords.py
+++ b/src/flownet/realization/_simulation_keywords.py
@@ -116,6 +116,7 @@ class WCONHIST(Keyword):
         artificial_lift: str = "1*",
         thp: float = np.nan,
         bhp: float = np.nan,
+        temperature: float = np.nan,
     ):
         super().__init__(date)
         self.name = "WCONHIST"
@@ -134,6 +135,7 @@ class WCONHIST(Keyword):
         self.artificial_lift: str = artificial_lift
         self.thp: float = thp
         self.bhp: float = bhp
+        self.temperature: float = temperature
 
 
 class WCONINJH(Keyword):
@@ -241,3 +243,24 @@ class WSALT(Keyword):
         self.name = "WSALT"
         self.well_name: str = well_name
         self.salt_concentration: float = salt_concentration
+
+class WTEMP(Keyword):
+    """
+    The WTEMP keyword defines the temperature of the injected water.
+
+    See the OPM Flow manual for further details.
+
+    """
+
+    # pylint: disable=too-many-instance-attributes,too-many-arguments
+
+    def __init__(
+        self,
+        date: datetime.date,
+        well_name: str,
+        temperature: float = np.nan,
+    ):
+        super().__init__(date)
+        self.name = "WTEMP"
+        self.well_name: str = well_name
+        self.temperature: float = temperature

--- a/src/flownet/realization/_simulation_keywords.py
+++ b/src/flownet/realization/_simulation_keywords.py
@@ -96,7 +96,7 @@ class WCONHIST(Keyword):
 
     """
 
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-instance-attributes,too-many-arguments
 
     def __init__(
         self,
@@ -149,7 +149,7 @@ class WCONINJH(Keyword):
 
     """
 
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-instance-attributes,too-many-arguments
 
     def __init__(
         self,

--- a/src/flownet/realization/_simulation_keywords.py
+++ b/src/flownet/realization/_simulation_keywords.py
@@ -244,6 +244,7 @@ class WSALT(Keyword):
         self.well_name: str = well_name
         self.salt_concentration: float = salt_concentration
 
+
 class WTEMP(Keyword):
     """
     The WTEMP keyword defines the temperature of the injected water.

--- a/src/flownet/static/SUMMARY.inc
+++ b/src/flownet/static/SUMMARY.inc
@@ -163,3 +163,9 @@ WSPT
 /
 WSIT
 /
+
+-- Temperature
+WTPCHEA 
+/
+WTICHEA 
+/

--- a/src/flownet/templates/HISTORY_SCHEDULE.inc.jinja2
+++ b/src/flownet/templates/HISTORY_SCHEDULE.inc.jinja2
@@ -50,6 +50,16 @@ WSALT
 /
 {%- endif %}
 
+{%- if schedule.get_keywords(dates=date, kw_class="WTEMP"): %}
+WTEMP
+-- WELL FLUID
+-- NAME TEMPERATURE
+{%- for kw in schedule.get_keywords(dates=date, kw_class="WTEMP"): %}
+ '{{ kw.well_name }}' {{ kw.temperature }} /
+{%- endfor %}
+/
+{%- endif %}
+
 {%- if date > startdate: %}
 DATES
  {{ date.strftime('%d %b %Y').upper() }} /

--- a/src/flownet/templates/TEMPLATE_MODEL.DATA.jinja2
+++ b/src/flownet/templates/TEMPLATE_MODEL.DATA.jinja2
@@ -40,10 +40,6 @@ INCLUDE
 INCLUDE
  './include/RUNSPEC.inc' /
 
-{% if schedule.has_brine() -%}
-BRINE
-{%- endif %}
-
 ----
 GRID
 ----

--- a/src/flownet/templates/observations.ertobs.jinja2
+++ b/src/flownet/templates/observations.ertobs.jinja2
@@ -36,6 +36,9 @@ SUMMARY_OBSERVATION WBHP_{{ kw.well_name }}_{{ index_name }} { VALUE = {{ kw.bhp
 {%- if not isnan(kw.thp) and error_config.WTHP.rel_error is not none and error_config.WTHP.min_error is not none: %}
 SUMMARY_OBSERVATION WTHP_{{ kw.well_name }}_{{ index_name }} { VALUE = {{ kw.thp }}; ERROR = {{ [error_config.WTHP.rel_error * kw.thp, error_config.WTHP.min_error] | max }}; DATE = {{ date_formatted  }}; KEY = WTHP:{{ kw.well_name }}; };
 {%- endif %}
+{%- if not isnan(kw.temperature) and error_config.WTPCHEA.rel_error is not none and error_config.WTPCHEA.min_error is not none: %}
+SUMMARY_OBSERVATION WTPCHEA_{{ kw.well_name }}_{{ index_name }} { VALUE = {{ kw.temperature }}; ERROR = {{ [error_config.WTPCHEA.rel_error * kw.temperature, error_config.WTPCHEA.min_error] | max }}; DATE  = {{ date_formatted  }}; KEY = WTPCHEA:{{ kw.well_name }}; };
+{%- endif %}
 
 {% endfor %}
 {%- endif %}

--- a/src/flownet/templates/observations.yamlobs.jinja2
+++ b/src/flownet/templates/observations.yamlobs.jinja2
@@ -170,6 +170,23 @@ smry:
         {%- endif -%}      
    {%- endfor %}
    {%- endif -%}
+   {%- if (error_config.WTPCHEA.rel_error is not none) and (error_config.WTPCHEA.min_error is not none) -%}
+   {%- for kw in schedule.get_keywords(kw_class="WCONHIST", well_name=well_name, ignore_nan="temperature", dates=dates[num_beginning_date:num_end_date]) -%}
+   {% if loop.first and not loop.last: %}
+ - key: WTPCHEA:{{ well_name }}
+   observations:
+   {%- endif %}
+    - date: {{ kw.date.strftime('%Y-%m-%d') }}
+      value: {{ kw.temperature }}
+      error: {{ [error_config.WTPCHEA.rel_error * kw.temperature, error_config.WTPCHEA.min_error] | max }}
+      comment:
+        {%- if (kw.date > last_training_date) -%}
+        {{ " Test" }}
+        {%- else -%}
+        {{ " Training" }}
+        {%- endif -%}      
+   {%- endfor %}
+   {%- endif -%}
 {%- endfor -%}
 
 {% for well_name in schedule.get_wells(kw_class="WCONINJH") %}

--- a/tests/test_check_obsfiles_ert_yaml.py
+++ b/tests/test_check_obsfiles_ert_yaml.py
@@ -287,6 +287,12 @@ def test_check_obsfiles_ert_yaml() -> None:
     config.flownet.data_source.vectors.WSIT.min_error = _MIN_ERROR
     config.flownet.data_source.vectors.WSIT.rel_error = _REL_ERROR
 
+    config.flownet.data_source.vectors.WTPCHEA = collections.namedtuple(
+        "WTPCHEA", "min_error"
+    )
+    config.flownet.data_source.vectors.WTPCHEA.min_error = _MIN_ERROR
+    config.flownet.data_source.vectors.WTPCHEA.rel_error = _REL_ERROR
+
     config.flownet.data_source.resampling = _RESAMPLING
 
     # Load production


### PR DESCRIPTION
The purpose of this PR is to allow for history matching production fluid temperatures. Main adjustement:
1) keyword `WTPCHEA` (temperature of producers) added for parsing  (`_config_parser.py`)
2) extended `phases` with additional element `temp`. Also `brine` is allowed now to be specified under `phases` item in the yml config file. Thus the items `'oil', 'gas', 'water', 'disgas', 'vapoil', 'brine' and 'temp'` can all be specified now under the `phases` keyword. (Note the term `phases ` is not so appropriate anymore and should may be renamed) (`_config_parser.py`)
3) added `WTPCHEA` and `WTICHEA` to dataframe (`from_flow.py`)
4) helper function adedd to create `WTEMP` for injection temperature specification. The `has_brine` method commented out as `brine` keyword should now be specified via `phases` keyword in the config yml file (`_schedule.py`)
5) further adjustments to template files to enable `WTEMP` writing to schedule include file and to allow for production temperature observations

todo: 
1) Enable specifying grid property THCONR ( total thermal conductivity) as static property for a flownet simulation. See issue #442 
2) add a brine +thermal test case to flownet-testdata repository
3) update documentation and changelog
