### PR TITLE
Enables running ERT in ensemble_experiment mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changes
 - [#440](https://github.com/equinor/flownet/pull/440) Speeds up workflow by removing search for well starting date from inside for-loop when processing historical production data in `_schedule.py`.
+- [#451](https://github.com/equinor/flownet/pull/451) Enables `flownet ahm` to run ERT in `ensemble_experiment` mode so that only the prior ensemble is simulated (i.e. without performing iterations of history matching or model updates). Entry `ert.ensemble_weights` of configuration file is now optional: when weights are not provided, ERT will be run in `ensemble_experiment` mode instead of `es_mda`.
 
 ## [0.5.3] - 2021-09-23
 

--- a/docs/configuration_file.rst
+++ b/docs/configuration_file.rst
@@ -517,7 +517,7 @@ The maximum number of simulation jobs executed simultaneously.
 ensemble_weights
 ----------------
 
-A list with weights assigned to the iteration in the ES MDA algorithm.
+A list with weights assigned to the iteration in the ES MDA algorithm. When this list is not provided, FlowNet will run ERT in ensemble_experiment mode (i.e. only prior ensemble or iter-0 will be run, without performing iterations of the history matching or model updates).
 
 yamlobs
 -------

--- a/src/flownet/ahm/_assisted_history_matching.py
+++ b/src/flownet/ahm/_assisted_history_matching.py
@@ -1,5 +1,5 @@
 import argparse
-from typing import List
+from typing import List, Optional
 from configsuite import ConfigSuite
 import jinja2
 import numpy as np
@@ -69,7 +69,7 @@ class AssistedHistoryMatching:
             training_set_fraction=training_set_fraction,
         )
 
-    def run_ert(self, weights: List[float]):
+    def run_ert(self, weights: Optional[List[float]] = None):
         """
         This function will start running ert (assumes create_ert_setup has been called).
 
@@ -101,12 +101,20 @@ class AssistedHistoryMatching:
                 )
             )
 
-        run_ert_subprocess(
-            f"ert es_mda --weights {','.join(map(str, weights))!r} ahm_config.ert",
-            cwd=self.output_folder,
-            runpath=self._config.ert.runpath,
-            timeout=self._config.ert.timeout,
-        )
+        if weights:
+            run_ert_subprocess(
+                f"ert es_mda --weights {','.join(map(str, weights))!r} ahm_config.ert",
+                cwd=self.output_folder,
+                runpath=self._config.ert.runpath,
+                timeout=self._config.ert.timeout,
+            )
+        else:
+            run_ert_subprocess(
+                "ert ensemble_experiment ahm_config.ert",
+                cwd=self.output_folder,
+                runpath=self._config.ert.runpath,
+                timeout=self._config.ert.timeout,
+            )
 
     def report(self):
         """

--- a/src/flownet/config_parser/_config_parser.py
+++ b/src/flownet/config_parser/_config_parser.py
@@ -670,7 +670,11 @@ def create_schema(config_folder: Optional[pathlib.Path] = None) -> Dict:
                     },
                     "ensemble_weights": {
                         MK.Type: types.List,
-                        MK.Content: {MK.Item: {MK.Type: types.Number}},
+                        MK.Content: {
+                            MK.Item: {MK.Type: types.Number, MK.AllowNone: True}
+                        },
+                        MK.Description: "List of weights assigned to the iterations "
+                        "of the ES-MDA algorithm",
                     },
                     "yamlobs": {
                         MK.Type: types.String,


### PR DESCRIPTION
*Enables `flownet ahm` to run ERT in `ensemble_experiment` mode to facilitate evaluation of prior ensemble only*

---

### Contributor checklist

- [ ] :tada: This PR closes #447.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Change `config_parser` to allow for `ert.ensemble_weights` to become optional entry in the configuration file
   - [ ] Change `run_ahm` to run ERT in `ensemble_experiment` mode if no weights are provided
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`.
- [ ] :books: I have considered updating the documentation.